### PR TITLE
Add aria-labelledby to TextInput

### DIFF
--- a/aries-site/src/layouts/navigation/Search.js
+++ b/aries-site/src/layouts/navigation/Search.js
@@ -6,6 +6,7 @@ import React, {
   useCallback,
 } from 'react';
 import { useRouter } from 'next/router';
+import styled from 'styled-components';
 import PropTypes from 'prop-types';
 import { Box, Keyboard, TextInput, ResponsiveContext } from 'grommet';
 import { Search as SearchIcon } from 'grommet-icons';
@@ -13,6 +14,13 @@ import { structure } from '../../data';
 import { nameToPath } from '../../utils';
 
 const allSuggestions = structure.map(p => p.name).sort();
+
+// Using Search icon as the arialabelledby for the text input. Documentation
+// on why this is a valid replacement for using label here:
+// https://www.w3.org/WAI/tutorials/forms/labels/#using-aria-labelledby
+const StyledTextInput = styled(TextInput).attrs(() => ({
+  'aria-labelledby': 'searchbutton',
+}))``;
 
 export const Search = ({ focused, setFocused }) => {
   const router = useRouter();
@@ -90,7 +98,7 @@ export const Search = ({ focused, setFocused }) => {
     >
       {size !== 'small' || focused ? (
         <Keyboard onEsc={() => setFocused(false)} onEnter={onEnter}>
-          <TextInput
+          <StyledTextInput
             ref={inputRef}
             dropTarget={boxRef.current}
             dropProps={{
@@ -118,7 +126,7 @@ export const Search = ({ focused, setFocused }) => {
             : undefined
         }
       >
-        <SearchIcon color="text" />
+        <SearchIcon id="searchbutton" color="text" />
       </Box>
     </Box>
   );

--- a/aries-site/src/layouts/navigation/Search.js
+++ b/aries-site/src/layouts/navigation/Search.js
@@ -18,6 +18,7 @@ const allSuggestions = structure.map(p => p.name).sort();
 // Using Search icon as the arialabelledby for the text input. Documentation
 // on why this is a valid replacement for using label here:
 // https://www.w3.org/WAI/tutorials/forms/labels/#using-aria-labelledby
+// https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/forms/Basic_form_hints
 const StyledTextInput = styled(TextInput).attrs(() => ({
   'aria-labelledby': 'searchbutton',
 }))``;

--- a/aries-site/src/layouts/navigation/Search.js
+++ b/aries-site/src/layouts/navigation/Search.js
@@ -20,7 +20,7 @@ const allSuggestions = structure.map(p => p.name).sort();
 // https://www.w3.org/WAI/tutorials/forms/labels/#using-aria-labelledby
 // https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/forms/Basic_form_hints
 const StyledTextInput = styled(TextInput).attrs(() => ({
-  'aria-labelledby': 'searchbutton',
+  'aria-labelledby': 'search-icon',
 }))``;
 
 export const Search = ({ focused, setFocused }) => {
@@ -127,7 +127,7 @@ export const Search = ({ focused, setFocused }) => {
             : undefined
         }
       >
-        <SearchIcon id="searchbutton" color="text" />
+        <SearchIcon id="search-icon" color="text" />
       </Box>
     </Box>
   );


### PR DESCRIPTION
Using Search icon as the arialabelledby for the text input. Documentation on why this is a valid replacement for using label here: https://www.w3.org/WAI/tutorials/forms/labels/#using-aria-labelledby. More info can also be found here: https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/forms/Basic_form_hints

At first, I tried to use grommet formField with the text input, but I was running into issues with how it affected the styling of the component. Instead, I decided to go for this aria approach since adhering to the designs would've required visually hiding the label anyway. There is enough visual context for the user to know that the textinput is a search form, so it meets the requirements of the above resources. Open to discussion on this approach.