### PR TITLE
Allow flex so that footer content stays at bottom

### DIFF
--- a/aries-site/src/layouts/main/SidebarLayout.js
+++ b/aries-site/src/layouts/main/SidebarLayout.js
@@ -25,6 +25,7 @@ export const SidebarLayout = ({ title, children }) => {
               horizontal: size !== 'small' ? 'xlarge' : 'large',
               vertical: 'large',
             }}
+            flex
           >
             <Main flex>
               {children}


### PR DESCRIPTION
Letting this Box flex allows it to fill any height of the window that wasn't being taken up by content and pushes "NextContent" to the bottom of the window when content isn't large enough to take up the entire window height..