### PR TITLE
Make Tiles and NavPage items <a> in DOM

### DIFF
--- a/aries-site/src/layouts/navigation/NavPage.js
+++ b/aries-site/src/layouts/navigation/NavPage.js
@@ -1,7 +1,7 @@
 import React, { useContext } from 'react';
 import Link from 'next/link';
 import PropTypes from 'prop-types';
-import { Box, Text, Paragraph, ResponsiveContext } from 'grommet';
+import { Box, Button, Text, Paragraph, ResponsiveContext } from 'grommet';
 import { iconsMap } from '../../components/icons/iconsMap';
 import { structure } from '../../data';
 
@@ -16,21 +16,26 @@ const NavItem = ({ item, topic }) => {
   return (
     // Need to pass href because of: https://github.com/zeit/next.js/#forcing-the-link-to-expose-href-to-its-child
     <Link href={`/${topic}/${formattedItem}`} passHref>
-      <Box
-        direction="row"
-        margin={{ vertical: 'large' }}
-        gap={size !== 'small' ? 'large' : 'medium'}
-      >
-        {/* Adds placeholder icon for the meantime
-         * while we wait to get all the icons */}
-        {itemData.icon ? itemData.icon('xlarge') : iconsMap.branding('xlarge')}
-        <Box>
-          <Text weight="bold" size={size !== 'small' ? 'large' : 'medium'}>
-            {itemData.name}
-          </Text>
-          <Paragraph size="small">{itemData.description}</Paragraph>
+      {/* Needs to be <a> in DOM for web crawling: https://support.google.com/webmasters/answer/9112205?hl=en */}
+      <Button fill>
+        <Box
+          direction="row"
+          margin={{ vertical: 'large' }}
+          gap={size !== 'small' ? 'large' : 'medium'}
+        >
+          {/* Adds placeholder icon for the meantime
+           * while we wait to get all the icons */}
+          {itemData.icon
+            ? itemData.icon('xlarge')
+            : iconsMap.branding('xlarge')}
+          <Box>
+            <Text weight="bold" size={size !== 'small' ? 'large' : 'medium'}>
+              {itemData.name}
+            </Text>
+            <Paragraph size="small">{itemData.description}</Paragraph>
+          </Box>
         </Box>
-      </Box>
+      </Button>
     </Link>
   );
 };

--- a/aries-site/src/pages/index.js
+++ b/aries-site/src/pages/index.js
@@ -25,11 +25,15 @@ const HomeTiles = ({ ...rest }) => {
 // Reasoning for using forwardRef: https://nextjs.org/docs/api-reference/next/link#example-with-reactforwardref
 const TopicTile = forwardRef(({ topic, ...rest }, ref) => {
   return (
+    // Needs to be <a> in DOM for web crawling: https://support.google.com/webmasters/answer/9112205?hl=en
     <Tile
+      as="a"
       pad="medium"
       background={topic.color}
       key={topic.color}
       ref={ref}
+      fill
+      style={{ textDecoration: 'none' }}
       {...rest}
     >
       <TileContent


### PR DESCRIPTION
Motivated by Issue #256: In order for links to be crawlable, elements with href need to be <a> in the DOM. This PR adjust the home tiles and navpage items to be <a href=... /> in the DOM.

Resource here: https://support.google.com/webmasters/answer/9112205?hl=en