### PR TITLE
Add Netlify preview wait to build actions.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,6 +5,12 @@ jobs:
   audit:
     runs-on: ubuntu-latest
     steps:
+      - name: Waiting for Netlify Preview
+        uses: josephduffy/wait-for-netlify-action@v1
+        id: wait-for-netflify-preview
+        with:
+          site_name: 'keen-mayer-a86c8b'
+          max_timeout: 320
       - name: Lighthouse audit Netlify deploy preview
         uses: jakejarvis/lighthouse-action@master
         with:


### PR DESCRIPTION
Fixes a race condition where Lighthouse tries to audit a non-existent Netlify URL.