### PR TITLE
Create reusable tab function

### DIFF
--- a/aries-site/src/tests/functions.js
+++ b/aries-site/src/tests/functions.js
@@ -8,6 +8,22 @@ export const formatForTyping = ClientFunction(text => text.split('').join(' '));
 
 export const repeatKeyPress = ClientFunction((key, number) => {
   // Array.join puts the argument between the array elements,
-  // so we need to add 1
+  // so we need to add 1 to get the correct output
   return Array(number + 1).join(`${key} `);
+});
+
+// find how many tabs it takes to reach desired element
+export const getTabCount = ClientFunction(expectedPath => {
+  const tabbableElements = document.querySelectorAll(
+    // eslint-disable-next-line max-len
+    'button, body [href], input, select, textarea, [tabindex]:not([tabindex="-1"])',
+  );
+
+  let hrefIndex;
+  for (let i = 0; i < tabbableElements.length; i += 1) {
+    if (tabbableElements[i].getAttribute('href') === expectedPath) {
+      hrefIndex = i;
+    }
+  }
+  return hrefIndex;
 });

--- a/aries-site/src/tests/navigation.js
+++ b/aries-site/src/tests/navigation.js
@@ -1,6 +1,6 @@
 /* eslint-disable no-undef */
 import { Selector } from 'testcafe';
-import { baseUrl, getLocation, repeatKeyPress } from './functions';
+import { baseUrl, getLocation, repeatKeyPress, getTabCount } from './functions';
 
 fixture('Navigation home tiles').page(baseUrl);
 
@@ -8,6 +8,7 @@ test('home tile with mouse click', async t => {
   const page = 'Components';
   const element = Selector('[data-test-id="anchor-tile"]').withText(page);
   const expectedPath = await element.getAttribute('href');
+
   await t
     .click(element)
     .expect(getLocation())
@@ -18,8 +19,9 @@ test('home tile with keyboard', async t => {
   const page = 'Components';
   const element = Selector('[data-test-id="anchor-tile"]').withText(page);
   const expectedPath = await element.getAttribute('href');
+
   await t
-    .pressKey(await repeatKeyPress('tab', 6))
+    .pressKey(await repeatKeyPress('tab', await getTabCount(expectedPath)))
     .pressKey('enter')
     .expect(getLocation())
     .contains(expectedPath);
@@ -31,6 +33,7 @@ test('Topic with mouse click', async t => {
   const page = 'Guidelines';
   const element = Selector('[data-test-id="topic"]').withText(page);
   const expectedPath = await element.getAttribute('href');
+
   await t
     .click(element)
     .expect(getLocation())
@@ -41,19 +44,21 @@ test('Topic with keyboard', async t => {
   const page = 'Guidelines';
   const element = Selector('[data-test-id="topic"]').withText(page);
   const expectedPath = await element.getAttribute('href');
+
   await t
-    .pressKey(await repeatKeyPress('tab', 4))
+    .pressKey(await repeatKeyPress('tab', await getTabCount(expectedPath)))
     .pressKey('enter')
     .expect(getLocation())
     .contains(expectedPath);
 });
 
-fixture('Side Bar Nav').page('http://localhost:3000/guidelines/principles');
+fixture('Side Bar Nav').page(`${baseUrl}/guidelines/principles`);
 
 test('Side Bar Nav with mouse click', async t => {
   const page = 'Philosophy';
   const element = Selector('[data-test-id="side-bar"]').withText(page);
   const expectedPath = await element.getAttribute('href');
+
   await t
     .click(element)
     .expect(getLocation())
@@ -64,20 +69,24 @@ test('Side Bar with keyboard', async t => {
   const page = 'Philosophy';
   const element = Selector('[data-test-id="side-bar"]').withText(page);
   const expectedPath = await element.getAttribute('href');
+
   await t
-    .pressKey(await repeatKeyPress('tab', 10))
+    .pressKey(await repeatKeyPress('tab', await getTabCount(expectedPath)))
     .pressKey('enter')
     .expect(getLocation())
     .contains(expectedPath);
 });
 
-fixture('Next Content').page('http://localhost:3000/foundation/branding');
+fixture('Next Content').page(`${baseUrl}/foundation/branding`);
 
 test('Next Content with mouse click', async t => {
   const page = 'Color';
   const element = Selector('[data-test-id="next-content"]').withText(page);
   const expectedPath = await element.getAttribute('href');
+
+  // Need to maximize window so that link isn't hidden behind theme toggle
   await t
+    .maximizeWindow()
     .click(element)
     .expect(getLocation())
     .contains(expectedPath);
@@ -89,7 +98,7 @@ test('Next Content with keyboard', async t => {
   const expectedPath = await element.getAttribute('href');
 
   await t
-    .pressKey(await repeatKeyPress('tab', 19))
+    .pressKey(await repeatKeyPress('tab', await getTabCount(expectedPath)))
     .pressKey('enter')
     .expect(getLocation())
     .contains(expectedPath);
@@ -114,7 +123,7 @@ test('NavPage items with keyboard', async t => {
   const expectedPath = await element.getAttribute('href');
 
   await t
-    .pressKey(await repeatKeyPress('tab', 4))
+    .pressKey(await repeatKeyPress('tab', await getTabCount(expectedPath)))
     .pressKey('enter')
     .expect(getLocation())
     .contains(expectedPath);

--- a/aries-site/src/tests/navigation.js
+++ b/aries-site/src/tests/navigation.js
@@ -84,7 +84,7 @@ test('Next Content with mouse click', async t => {
   const element = Selector('[data-test-id="next-content"]').withText(page);
   const expectedPath = await element.getAttribute('href');
 
-  // Need to maximize window so that link isn't hidden behind theme toggle
+  // Need to maximize window so that link isn't hidden behind theme toggle otherwise test will fail
   await t
     .maximizeWindow()
     .click(element)


### PR DESCRIPTION
Instead of hard-coding the number of tabs, this let's use dynamically find how many tabs it would take to reach the desired element. Then, the test uses that value to hit tab that many times.