### PR TITLE
Update search tests to fit naming convention/remove data-test-id

### DIFF
--- a/aries-site/package.json
+++ b/aries-site/package.json
@@ -25,7 +25,7 @@
     "start": "next",
     "start-server": "yarn build && yarn next start",
     "test": "yarn build && node src/scripts/start-tests.js",
-    "test:local": "start-server-and-test start-server 3000 'testcafe all src/tests/search.js'",
+    "test:local": "start-server-and-test start-server 3000 'testcafe all src/tests/'",
     "lint": "eslint src",
     "lint-fix": "eslint src --fix"
   },

--- a/aries-site/package.json
+++ b/aries-site/package.json
@@ -25,7 +25,7 @@
     "start": "next",
     "start-server": "yarn build && yarn next start",
     "test": "yarn build && node src/scripts/start-tests.js",
-    "test:local": "start-server-and-test start-server 3000 'testcafe all src/tests/'",
+    "test:local": "start-server-and-test start-server 3000 'testcafe all src/tests/search.js'",
     "lint": "eslint src",
     "lint-fix": "eslint src --fix"
   },

--- a/aries-site/src/layouts/navigation/Search.js
+++ b/aries-site/src/layouts/navigation/Search.js
@@ -85,7 +85,6 @@ export const Search = ({ focused, setFocused }) => {
   return (
     <Box
       ref={boxRef}
-      data-test-id="search"
       align="center"
       background={
         size !== 'small' || focused ? 'background-contrast' : undefined
@@ -108,7 +107,6 @@ export const Search = ({ focused, setFocused }) => {
                 // push drop just below focus indicator of text input
                 top: '3px',
               },
-              'data-test-id': 'suggestions',
             }}
             dropHeight="small"
             onChange={onChange}


### PR DESCRIPTION
Leverages ReactSelector instead of adding data-test-id, updates naming convention.