### PR TITLE
Don't merge — Create script to create structure file for test

### DIFF
--- a/aries-site/package.json
+++ b/aries-site/package.json
@@ -7,6 +7,7 @@
   "private": true,
   "dependencies": {
     "aries-core": "*",
+    "fs": "0.0.1-security",
     "grommet": "https://github.com/grommet/grommet/tarball/stable",
     "grommet-icons": "^4.4.0",
     "grommet-theme-hpe": "https://github.com/grommet/grommet-theme-hpe/tarball/stable",
@@ -21,7 +22,7 @@
     "export": "yarn build && next export",
     "postexport": "node next.postexport.js",
     "start": "next",
-    "start-server": "yarn build && yarn next start",
+    "start-server": "yarn build && node src/scripts/createStructureFile.js && yarn next start",
     "test": "yarn build && node src/scripts/start-tests.js",
     "test:local": "start-server-and-test start-server 3000 'testcafe all src/tests/'",
     "lint": "eslint src",

--- a/aries-site/src/scripts/createStructureFile.js
+++ b/aries-site/src/scripts/createStructureFile.js
@@ -1,0 +1,6 @@
+const fs = require('fs-extra');
+const getStructure = require('./getStructure');
+
+const structure = getStructure();
+
+fs.writeFileSync('src/tests/structure.json', structure);

--- a/aries-site/src/scripts/getStructure.js
+++ b/aries-site/src/scripts/getStructure.js
@@ -1,0 +1,9 @@
+const structure = require('../data/structure');
+
+module.exports = () => {
+  const structureCopy = JSON.parse(JSON.stringify(structure));
+
+  for (let i = 0; i < structureCopy.length; i += 1)
+    delete structureCopy[i].icon;
+  return structureCopy;
+};


### PR DESCRIPTION
trying to create file that eliminates the "icon" property of the structure array so that TestCafe can utilize data structure for tests.