### PR TITLE
Removing 'Aries' from the site title

### DIFF
--- a/aries-site/src/components/seo/Meta.js
+++ b/aries-site/src/components/seo/Meta.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import Head from 'next/head';
 
 export const Meta = ({ title, description, canonicalUrl, socialImageUrl }) => {
-  const siteName = 'HPE Aries Design System';
+  const siteName = 'HPE Design System';
   const defaultImage = '/static/images/aries-introduction.jp2';
   const previewImage = socialImageUrl || defaultImage;
   const twitterHandle = null;


### PR DESCRIPTION
As the link for the site is being shared the SEO is using Meta data name to display the site title, and it shouldn't have Aries included

![image](https://user-images.githubusercontent.com/6320236/74972881-c23fe080-53df-11ea-8559-046ec3a00638.png)
