### PR TITLE
Control page/examples

### DIFF
--- a/aries-site/src/examples/components/controls/AccordionExample.js
+++ b/aries-site/src/examples/components/controls/AccordionExample.js
@@ -1,20 +1,10 @@
 import React from 'react';
 import { Accordion, AccordionPanel, Box } from 'grommet';
 
-import { UsageExample } from '../../../layouts';
-
 export const AccordionExample = () => {
   const pad = { vertical: 'medium' };
 
   return (
-    <UsageExample
-      pad={{
-        top: 'medium',
-        bottom: 'large',
-        horizontal: 'large',
-        small: { horizontal: 'large', top: 'medium', bottom: 'xlarge' },
-      }}
-    >
       <Accordion>
         <AccordionPanel label="Our Company">
           <Box pad={pad}>We are HPE.</Box>
@@ -35,6 +25,5 @@ export const AccordionExample = () => {
           <Box pad={pad}>We make Bold Moves.</Box>
         </AccordionPanel>
       </Accordion>
-    </UsageExample>
   );
 };

--- a/aries-site/src/examples/components/controls/MenuExample.js
+++ b/aries-site/src/examples/components/controls/MenuExample.js
@@ -2,8 +2,6 @@ import React from 'react';
 import { Box, Menu } from 'grommet';
 import { aries } from '../../../themes/aries';
 
-import { UsageExample } from '../../../layouts';
-
 export const MenuExample = () => {
   const items = [
     { label: 'Past 12 months' },
@@ -20,16 +18,8 @@ export const MenuExample = () => {
   const background = aries.global.colors.background.light;
 
   return (
-    <UsageExample
-      pad={{
-        horizontal: 'large',
-        vertical: 'large',
-        small: { horizontal: 'large', vertical: 'xlarge' },
-      }}
-    >
       <Box background={background} round="xsmall">
         <Menu label="Choose a timeframe" items={items} width="medium" />
       </Box>
-    </UsageExample>
   );
 };

--- a/aries-site/src/examples/components/controls/MenuExample.js
+++ b/aries-site/src/examples/components/controls/MenuExample.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import { Box, Menu } from 'grommet';
-import { aries } from '../../../themes/aries';
 
 export const MenuExample = () => {
   const items = [
@@ -11,14 +10,8 @@ export const MenuExample = () => {
     { label: 'Past 7 days' },
   ];
 
-  // Once themeMode toggle has been added I will make the background box toggle
-  // to the dark. There is a background placed behind the menu because otherwise
-  // the menu button blends in completely with the site background making it
-  // difficult to distinguish as an interactive component.
-  const background = aries.global.colors.background.light;
-
   return (
-      <Box background={background} round="xsmall">
+      <Box round="xsmall">
         <Menu label="Choose a timeframe" items={items} width="medium" />
       </Box>
   );

--- a/aries-site/src/examples/components/controls/TabsExample.js
+++ b/aries-site/src/examples/components/controls/TabsExample.js
@@ -10,21 +10,11 @@ import {
   Text,
 } from 'grommet';
 
-import { UsageExample } from '../../../layouts';
-
 export const TabsExample = () => {
   const [index, setIndex] = React.useState();
   const onActive = nextIndex => setIndex(nextIndex);
 
   return (
-    <UsageExample
-      height="medium"
-      pad={{
-        horizontal: 'large',
-        top: 'large',
-        small: { horizontal: 'medium', top: 'large' },
-      }}
-    >
       <Box>
         <Tabs activeIndex={index} onActive={onActive} justify="start">
           <Tab title="General">
@@ -69,6 +59,5 @@ export const TabsExample = () => {
           </Tab>
         </Tabs>
       </Box>
-    </UsageExample>
   );
 };

--- a/aries-site/src/pages/components/controls.js
+++ b/aries-site/src/pages/components/controls.js
@@ -43,7 +43,6 @@ const Controls = () => (
     </ContentSection>
     <ContentSection>
       <Subsection name="Accordion">
-        <AccordionExample />
         <SubsectionText>
           The accordian affords content to be delivered progressively. The
           chevron is used to identify the expand or collapse action while the
@@ -51,6 +50,11 @@ const Controls = () => (
           seeking to provide maximum content in limited, vertical space, an
           accordion is a good alternative.
         </SubsectionText>
+        <Example
+          docs="https://v2.grommet.io/accordion#props"
+          code="https://raw.githubusercontent.com/hpe-design/design-system/master/aries-site/src/examples/components/controls/AccordionExample.js">
+          <AccordionExample />
+        </Example>
       </Subsection>
     </ContentSection>
     <ContentSection>

--- a/aries-site/src/pages/components/controls.js
+++ b/aries-site/src/pages/components/controls.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import { Anchor } from 'grommet';
 
 import { Meta, SubsectionText } from '../../components';
 import {
@@ -67,7 +68,7 @@ const Controls = () => (
     </ContentSection>
     <ContentSection>
       <Subsection name="Button">
-      <SubsectionText>
+        <SubsectionText>
           Buttons are used to indicate actions that can be performed.
         </SubsectionText>
         <Example
@@ -82,10 +83,14 @@ const Controls = () => (
     </ContentSection>
     <ContentSection>
       <Subsection name="Menu">
-      <SubsectionText>
-          Menu is used to filter or sort content on a page. It is similar to the
-          select component. However, use the select component when the user must
-          specify from a list of options and submit. See the Select Component.
+        <SubsectionText>
+          Menu is used to filter or sort content on a page. It is
+          similar to the{' '}
+          <Anchor color="green!" href="input#select">
+            Select component
+          </Anchor>{' '}
+          However, use the select component when the user must specify from a
+          list of options and submit.
         </SubsectionText>
         <Example
           docs="https://v2.grommet.io/menu#props"
@@ -97,7 +102,7 @@ const Controls = () => (
     </ContentSection>
     <ContentSection>
       <Subsection name="Tabs">
-      <SubsectionText>
+        <SubsectionText>
           Tabs allow a user to access content while maintaining the existing
           context. It consists of a container, or box, with tab controls to
           expose the contents of the container.

--- a/aries-site/src/pages/components/controls.js
+++ b/aries-site/src/pages/components/controls.js
@@ -62,6 +62,9 @@ const Controls = () => (
     </ContentSection>
     <ContentSection>
       <Subsection name="Button">
+      <SubsectionText>
+          Buttons are used to indicate actions that can be performed.
+        </SubsectionText>
         <Example
           docs="https://v2.grommet.io/button?theme=hpe#props"
           code="https://raw.githubusercontent.com/hpe-design/design-system/master/aries-site/src/examples/components/controls/ButtonExample.js"
@@ -70,9 +73,6 @@ const Controls = () => (
         >
           <ButtonExample />
         </Example>
-        <SubsectionText>
-          Buttons are used to indicate actions that can be performed.
-        </SubsectionText>
       </Subsection>
     </ContentSection>
     <ContentSection>

--- a/aries-site/src/pages/components/controls.js
+++ b/aries-site/src/pages/components/controls.js
@@ -52,7 +52,8 @@ const Controls = () => (
         </SubsectionText>
         <Example
           docs="https://v2.grommet.io/accordion#props"
-          code="https://raw.githubusercontent.com/hpe-design/design-system/master/aries-site/src/examples/components/controls/AccordionExample.js">
+          code="https://raw.githubusercontent.com/hpe-design/design-system/master/aries-site/src/examples/components/controls/AccordionExample.js"
+        >
           <AccordionExample />
         </Example>
       </Subsection>
@@ -88,19 +89,25 @@ const Controls = () => (
         </SubsectionText>
         <Example
           docs="https://v2.grommet.io/menu#props"
-          code="https://raw.githubusercontent.com/hpe-design/design-system/master/aries-site/src/examples/components/controls/MenuExample.js">
+          code="https://raw.githubusercontent.com/hpe-design/design-system/master/aries-site/src/examples/components/controls/MenuExample.js"
+        >
           <MenuExample />
         </Example>
       </Subsection>
     </ContentSection>
     <ContentSection>
       <Subsection name="Tabs">
-        <TabsExample />
-        <SubsectionText>
+      <SubsectionText>
           Tabs allow a user to access content while maintaining the existing
           context. It consists of a container, or box, with tab controls to
           expose the contents of the container.
         </SubsectionText>
+        <Example
+          docs="https://v2.grommet.io/tabs#props"
+          code="https://raw.githubusercontent.com/hpe-design/design-system/master/aries-site/src/examples/components/controls/TabsExample.js"
+        >
+          <TabsExample />
+        </Example>
       </Subsection>
     </ContentSection>
   </Layout>

--- a/aries-site/src/pages/components/controls.js
+++ b/aries-site/src/pages/components/controls.js
@@ -81,12 +81,16 @@ const Controls = () => (
     </ContentSection>
     <ContentSection>
       <Subsection name="Menu">
-        <MenuExample />
-        <SubsectionText>
+      <SubsectionText>
           Menu is used to filter or sort content on a page. It is similar to the
           select component. However, use the select component when the user must
           specify from a list of options and submit. See the Select Component.
         </SubsectionText>
+        <Example
+          docs="https://v2.grommet.io/menu#props"
+          code="https://raw.githubusercontent.com/hpe-design/design-system/master/aries-site/src/examples/components/controls/MenuExample.js">
+          <MenuExample />
+        </Example>
       </Subsection>
     </ContentSection>
     <ContentSection>


### PR DESCRIPTION
Related Issue: #416 

Work Included: 
* Implemented the controls page examples to use the usage examples
* Each example will now have the more to view the code and other props

Screen Shots 
![Screen Shot 2020-02-25 at 12 28 11 PM](https://user-images.githubusercontent.com/42451602/75280253-576d1b80-57ca-11ea-9873-58275662bd9d.png)

