### PR TITLE
Input page/examples

### DIFF
--- a/aries-site/src/examples/components/input/CheckboxExample.js
+++ b/aries-site/src/examples/components/input/CheckboxExample.js
@@ -1,8 +1,6 @@
 import React, { useState } from 'react';
 import { Box, CheckBox } from 'grommet';
 
-import { UsageExample } from '../../../layouts';
-
 const items = ['C++', 'JavaScript', 'Python'];
 
 export const CheckboxExample = () => {
@@ -17,13 +15,6 @@ export const CheckboxExample = () => {
   };
 
   return (
-    <UsageExample
-      pad={{
-        horizontal: 'large',
-        vertical: 'large',
-        small: { horizontal: 'large', vertical: 'xlarge' },
-      }}
-    >
       <Box gap="medium">
         {items &&
           items.map(item => (
@@ -35,6 +26,5 @@ export const CheckboxExample = () => {
             />
           ))}
       </Box>
-    </UsageExample>
   );
 };

--- a/aries-site/src/examples/components/input/MaskedInputExample/MaskedInputExample.js
+++ b/aries-site/src/examples/components/input/MaskedInputExample/MaskedInputExample.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import { Box } from 'grommet';
 
-import { UsageExample } from '../../../../layouts';
 import {
   MaskedDateExample,
   MaskedEmailExample,
@@ -11,13 +10,6 @@ import {
 
 export const MaskedInputExample = () => {
   return (
-    <UsageExample
-      pad={{
-        horizontal: 'large',
-        vertical: 'large',
-        small: { horizontal: 'large', vertical: 'xlarge' },
-      }}
-    >
       <Box gap="medium">
         <Box direction="row-responsive" gap="large">
           <MaskedEmailExample />
@@ -28,6 +20,5 @@ export const MaskedInputExample = () => {
           <MaskedPhoneExample />
         </Box>
       </Box>
-    </UsageExample>
   );
 };

--- a/aries-site/src/examples/components/input/RadioButtonGroupExample.js
+++ b/aries-site/src/examples/components/input/RadioButtonGroupExample.js
@@ -1,8 +1,6 @@
 import React, { useState } from 'react';
 import { Box, RadioButtonGroup, Text } from 'grommet';
 
-import { UsageExample } from '../../../layouts';
-
 const powerRegulationOptions = [
   'Dynamic power savings mode',
   'Static low power mode',
@@ -16,13 +14,6 @@ export const RadioButtonGroupExample = () => {
   );
 
   return (
-    <UsageExample
-      pad={{
-        horizontal: 'large',
-        vertical: 'large',
-        small: { horizontal: 'large', vertical: 'xlarge' },
-      }}
-    >
       <Box gap="xsmall">
         <Text size="large">Power Management</Text>
         <Text>Power Regulation</Text>
@@ -36,6 +27,5 @@ export const RadioButtonGroupExample = () => {
           pad={{ vertical: 'medium' }}
         />
       </Box>
-    </UsageExample>
   );
 };

--- a/aries-site/src/examples/components/input/RangeInputExample.js
+++ b/aries-site/src/examples/components/input/RangeInputExample.js
@@ -1,19 +1,10 @@
 import React, { useState } from 'react';
 import { Box, RangeInput, Text } from 'grommet';
 
-import { UsageExample } from '../../../layouts';
-
 export const RangeInputExample = () => {
   const [value, setValue] = useState(80);
 
   return (
-    <UsageExample
-      pad={{
-        horizontal: 'large',
-        vertical: 'large',
-        small: { horizontal: 'large', vertical: 'xlarge' },
-      }}
-    >
       <Box gap="medium">
         <Box direction="row" gap="medium">
           <Text>Threshold</Text>
@@ -30,6 +21,5 @@ export const RangeInputExample = () => {
           <Text weight={600}>100</Text>
         </Box>
       </Box>
-    </UsageExample>
   );
 };

--- a/aries-site/src/examples/components/input/SelectExample.js
+++ b/aries-site/src/examples/components/input/SelectExample.js
@@ -1,8 +1,6 @@
 import React, { useState } from 'react';
 import { Box, Select } from 'grommet';
 
-import { UsageExample } from '../../../layouts';
-
 const defaultOptions = ['EMEA', 'Asia/Pacific', 'Americas', 'Polar Regions'];
 const placeholder = 'Location';
 
@@ -24,13 +22,6 @@ export const SelectExample = () => {
   };
 
   return (
-    <UsageExample
-      pad={{
-        horizontal: 'large',
-        vertical: 'large',
-        small: { horizontal: 'large', vertical: 'xlarge' },
-      }}
-    >
       <Box width="medium">
         <Select
           placeholder={placeholder}
@@ -41,6 +32,5 @@ export const SelectExample = () => {
           onSearch={text => onSearch(text)}
         />
       </Box>
-    </UsageExample>
   );
 };

--- a/aries-site/src/examples/components/input/TextAreaExample.js
+++ b/aries-site/src/examples/components/input/TextAreaExample.js
@@ -1,17 +1,8 @@
 import React from 'react';
 import { Box, FormField, TextArea } from 'grommet';
 
-import { UsageExample } from '../../../layouts';
-
 export const TextAreaExample = () => {
   return (
-    <UsageExample
-      pad={{
-        horizontal: 'large',
-        vertical: 'large',
-        small: { horizontal: 'large', vertical: 'xlarge' },
-      }}
-    >
       <Box width="medium">
         <FormField label="Additional feedback" htmlFor="text-area-example">
           <Box height="small">
@@ -23,6 +14,5 @@ export const TextAreaExample = () => {
           </Box>
         </FormField>
       </Box>
-    </UsageExample>
   );
 };

--- a/aries-site/src/examples/components/input/TextInputExample.js
+++ b/aries-site/src/examples/components/input/TextInputExample.js
@@ -1,8 +1,6 @@
 import React, { useState } from 'react';
 import { Box, FormField, TextInput } from 'grommet';
 
-import { UsageExample } from '../../../layouts';
-
 const usernamePlaceholder = 'Email address';
 const passwordPlaceholder = 'Password';
 
@@ -37,16 +35,8 @@ const LabelVerticalExample = () => {
 
 export const TextInputExample = () => {
   return (
-    <UsageExample
-      pad={{
-        horizontal: 'large',
-        vertical: 'large',
-        small: { horizontal: 'large', vertical: 'xlarge' },
-      }}
-    >
       <Box direction="row-responsive" gap="large" align="end">
         <LabelVerticalExample />
       </Box>
-    </UsageExample>
   );
 };

--- a/aries-site/src/pages/components/input.js
+++ b/aries-site/src/pages/components/input.js
@@ -59,7 +59,12 @@ const Input = () => (
         <SubsectionText>
           MaskedInput allows you to specify formailzed text within a form field.
         </SubsectionText>
-        <MaskedInputExample />
+        <Example
+          docs="https://v2.grommet.io/maskedinput#props"
+          code="https://raw.githubusercontent.com/hpe-design/design-system/master/aries-site/src/examples/components/input/MaskedInputExample/MaskedInputExample.js"
+        >
+          <MaskedInputExample />
+        </Example>
       </Subsection>
     </ContentSection>
     <ContentSection>

--- a/aries-site/src/pages/components/input.js
+++ b/aries-site/src/pages/components/input.js
@@ -60,7 +60,7 @@ const Input = () => (
           MaskedInput allows you to specify formailzed text within a form field.
         </SubsectionText>
         <Example
-          docs="https://v2.grommet.io/maskedinput#props"
+          docs="https://v2.grommet.io/maskedinput?theme=hpe#props"
           code="https://raw.githubusercontent.com/hpe-design/design-system/master/aries-site/src/examples/components/input/MaskedInputExample/MaskedInputExample.js"
         >
           <MaskedInputExample />

--- a/aries-site/src/pages/components/input.js
+++ b/aries-site/src/pages/components/input.js
@@ -89,7 +89,7 @@ const Input = () => (
           help ensure conficence in the use of the control.
         </SubsectionText>
         <Example
-          docs="https://v2.grommet.io/rangeinput#props"
+          docs="https://v2.grommet.io/rangeinput?theme=hpe#props"
           code="https://raw.githubusercontent.com/hpe-design/design-system/master/aries-site/src/examples/components/input/RangeInputExample.js">
           <RangeInputExample />
         </Example>

--- a/aries-site/src/pages/components/input.js
+++ b/aries-site/src/pages/components/input.js
@@ -73,7 +73,11 @@ const Input = () => (
           When one option of a set of options can be specified, use the
           RadioButtonGroup component.
         </SubsectionText>
-        <RadioButtonGroupExample />
+        <Example
+          docs="https://v2.grommet.io/radiobuttongroup#props"
+          code="https://raw.githubusercontent.com/hpe-design/design-system/master/aries-site/src/examples/components/input/RadioButtonGroupExample.js">
+          <RadioButtonGroupExample />
+        </Example>
       </Subsection>
     </ContentSection>
     <ContentSection>
@@ -84,7 +88,11 @@ const Input = () => (
           slider provides a value displayed to communicate with the user. This
           help ensure conficence in the use of the control.
         </SubsectionText>
-        <RangeInputExample />
+        <Example
+          docs="https://v2.grommet.io/rangeinput#props"
+          code="https://raw.githubusercontent.com/hpe-design/design-system/master/aries-site/src/examples/components/input/RangeInputExample.js">
+          <RangeInputExample />
+        </Example>
       </Subsection>
     </ContentSection>
     <ContentSection>
@@ -93,7 +101,11 @@ const Input = () => (
           The Select component is flexible to provide multiple select, search,
           and create options.
         </SubsectionText>
-        <SelectExample />
+        <Example
+          docs="https://v2.grommet.io/select#props"
+          code="https://raw.githubusercontent.com/hpe-design/design-system/master/aries-site/src/examples/components/input/SelectExample.js">
+          <SelectExample />
+        </Example>
       </Subsection>
     </ContentSection>
     <ContentSection>
@@ -104,7 +116,12 @@ const Input = () => (
           the user with ques to the type of data that is expected in the text
           field.
         </SubsectionText>
-        <TextAreaExample />
+        <Example
+          docs="https://v2.grommet.io/textarea#props"
+          code="https://raw.githubusercontent.com/hpe-design/design-system/master/aries-site/src/examples/components/input/TextAreaExample.js"
+        >
+          <TextAreaExample />
+        </Example>
       </Subsection>
     </ContentSection>
     <ContentSection>
@@ -115,7 +132,11 @@ const Input = () => (
           component. Style can be variable, based upon the use case and customer
           need that will elicit user confidence in success.
         </SubsectionText>
-        <TextInputExample />
+        <Example
+          docs="https://v2.grommet.io/textinput#props"
+          code="https://raw.githubusercontent.com/hpe-design/design-system/master/aries-site/src/examples/components/input/TextInputExample.js">
+          <TextInputExample />
+        </Example>
       </Subsection>
     </ContentSection>
     <ContentSection>

--- a/aries-site/src/pages/components/input.js
+++ b/aries-site/src/pages/components/input.js
@@ -42,75 +42,74 @@ const Input = () => (
     </ContentSection>
     <ContentSection>
       <Subsection name="Checkbox">
-        <CheckboxExample />
-        <SubsectionText>
+      <SubsectionText>
           When the user needs to select one or more options, use a checkbox. The
           click target should include the checkbox label.
         </SubsectionText>
+        <CheckboxExample />
       </Subsection>
     </ContentSection>
     <ContentSection>
       <Subsection name="MaskedInput">
-        <MaskedInputExample />
         <SubsectionText>
           MaskedInput allows you to specify formailzed text within a form field.
         </SubsectionText>
+        <MaskedInputExample />
       </Subsection>
     </ContentSection>
     <ContentSection>
       <Subsection name="RadioButtonGroup">
-        <RadioButtonGroupExample />
         <SubsectionText>
           When one option of a set of options can be specified, use the
           RadioButtonGroup component.
         </SubsectionText>
+        <RadioButtonGroupExample />
       </Subsection>
     </ContentSection>
     <ContentSection>
       <Subsection name="RangeInput">
-        <RangeInputExample />
         <SubsectionText>
           The RangeInput component is a slider control that provides a handle
           the user can move to make changes to values. It is important that the
           slider provides a value displayed to communicate with the user. This
           help ensure conficence in the use of the control.
         </SubsectionText>
+        <RangeInputExample />
       </Subsection>
     </ContentSection>
     <ContentSection>
       <Subsection name="Select">
-        <SelectExample />
         <SubsectionText>
           The Select component is flexible to provide multiple select, search,
           and create options.
         </SubsectionText>
+        <SelectExample />
       </Subsection>
     </ContentSection>
     <ContentSection>
       <Subsection name="TextArea">
-        <TextAreaExample />
         <SubsectionText>
           When you need to allow the user to provide longer forms of content,
           use a TextArea component. Sometimes, using placeholder text provides
           the user with ques to the type of data that is expected in the text
           field.
         </SubsectionText>
+        <TextAreaExample />
       </Subsection>
     </ContentSection>
     <ContentSection>
       <Subsection name="TextInput">
-        <TextInputExample />
         <SubsectionText>
           The TextInput component allows the user to input shorter forms of data
           and content. Passwords and tags can also be used with the TextInput
           component. Style can be variable, based upon the use case and customer
           need that will elicit user confidence in success.
         </SubsectionText>
+        <TextInputExample />
       </Subsection>
     </ContentSection>
     <ContentSection>
       <Subsection name="Form">
-        <FormExample />
         <SubsectionText>
           The Form component allows the user to provide various kinds of data.
           It is important to consider careful use of labels, help text,
@@ -118,6 +117,7 @@ const Input = () => (
           it’s fields should be relational and sensitive to sensemaking for the
           user.
         </SubsectionText>
+        <FormExample />
       </Subsection>
     </ContentSection>
   </Layout>

--- a/aries-site/src/pages/components/input.js
+++ b/aries-site/src/pages/components/input.js
@@ -133,7 +133,7 @@ const Input = () => (
           need that will elicit user confidence in success.
         </SubsectionText>
         <Example
-          docs="https://v2.grommet.io/textinput#props"
+          docs="https://v2.grommet.io/textinput?theme=hpe#props"
           code="https://raw.githubusercontent.com/hpe-design/design-system/master/aries-site/src/examples/components/input/TextInputExample.js">
           <TextInputExample />
         </Example>

--- a/aries-site/src/pages/components/input.js
+++ b/aries-site/src/pages/components/input.js
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import { Meta, SubsectionText } from '../../components';
-import { ContentSection, Layout, Subsection } from '../../layouts';
+import { ContentSection, Layout, Subsection, Example } from '../../layouts';
 import {
   CheckboxExample,
   FormExample,
@@ -46,7 +46,12 @@ const Input = () => (
           When the user needs to select one or more options, use a checkbox. The
           click target should include the checkbox label.
         </SubsectionText>
-        <CheckboxExample />
+        <Example
+          docs="https://v2.grommet.io/checkbox#props"
+          code="https://raw.githubusercontent.com/hpe-design/design-system/master/aries-site/src/examples/components/input/CheckboxExample.js"
+        >
+          <CheckboxExample />
+        </Example>
       </Subsection>
     </ContentSection>
     <ContentSection>

--- a/aries-site/src/pages/components/input.js
+++ b/aries-site/src/pages/components/input.js
@@ -74,7 +74,7 @@ const Input = () => (
           RadioButtonGroup component.
         </SubsectionText>
         <Example
-          docs="https://v2.grommet.io/radiobuttongroup#props"
+          docs="https://v2.grommet.io/radiobuttongroup?theme=hpe#props"
           code="https://raw.githubusercontent.com/hpe-design/design-system/master/aries-site/src/examples/components/input/RadioButtonGroupExample.js">
           <RadioButtonGroupExample />
         </Example>

--- a/aries-site/src/pages/components/input.js
+++ b/aries-site/src/pages/components/input.js
@@ -102,7 +102,7 @@ const Input = () => (
           and create options.
         </SubsectionText>
         <Example
-          docs="https://v2.grommet.io/select#props"
+          docs="https://v2.grommet.io/select?theme=hpe#props"
           code="https://raw.githubusercontent.com/hpe-design/design-system/master/aries-site/src/examples/components/input/SelectExample.js">
           <SelectExample />
         </Example>

--- a/aries-site/src/pages/components/input.js
+++ b/aries-site/src/pages/components/input.js
@@ -47,7 +47,7 @@ const Input = () => (
           click target should include the checkbox label.
         </SubsectionText>
         <Example
-          docs="https://v2.grommet.io/checkbox#props"
+          docs="https://v2.grommet.io/checkbox?theme=hpe#props"
           code="https://raw.githubusercontent.com/hpe-design/design-system/master/aries-site/src/examples/components/input/CheckboxExample.js"
         >
           <CheckboxExample />

--- a/aries-site/src/pages/components/input.js
+++ b/aries-site/src/pages/components/input.js
@@ -117,7 +117,7 @@ const Input = () => (
           field.
         </SubsectionText>
         <Example
-          docs="https://v2.grommet.io/textarea#props"
+          docs="https://v2.grommet.io/textarea?theme=hpe#props"
           code="https://raw.githubusercontent.com/hpe-design/design-system/master/aries-site/src/examples/components/input/TextAreaExample.js"
         >
           <TextAreaExample />


### PR DESCRIPTION
Related Issue #417 

## Work Included

* Moved subsection Text to be above each example
* Changed the examples to match usage example
* Took out `UsageExample` and replaced with `Example` layout

## Work not Included 
* Left the new `form example` at the bottom of the page that will most likely be moved to templates examples

