### PR TITLE
Feedback updates v1

### DIFF
--- a/aries-site/src/components/content/SubmitFeedback.js
+++ b/aries-site/src/components/content/SubmitFeedback.js
@@ -1,23 +1,149 @@
 import React from 'react';
-import { Anchor } from 'aries-core';
+import {
+  Box,
+  Button,
+  Form,
+  FormField,
+  Grid,
+  Layer,
+  MaskedInput,
+  ResponsiveContext,
+  Text,
+} from 'grommet';
+import { ChatOption, MailOption, Close, Github } from 'grommet-icons';
 import { ContentSection, Subsection } from '../../layouts/content';
 import { SubsectionText } from '.';
 
 export const SubmitFeedback = () => {
-  return (
-    <ContentSection lastSection>
-      <Subsection name="Still have questions?" level={2}>
-        <SubsectionText>
-          Something missing or looking for more information? Edit or open an
-          issue on Github to help us make the HPE Design-System better.
-        </SubsectionText>
-        <Anchor
+  const size = React.useContext(ResponsiveContext);
+  const [open, setOpen] = React.useState();
+  const onOpen = () => setOpen(true);
+  const onClose = () => setOpen(undefined);
+
+  const Subscribe = () => (
+    <Box gap="medium">
+      <MailOption size="large" />
+      <Text weight="bold" size="large">
+        Stay up-to-date
+      </Text>
+      <SubsectionText>
+        Get the latest feature enhancements and announcements directly to your
+        inbox.
+      </SubsectionText>
+      <Form>
+        <Box gap="small">
+          <FormField margin="none">
+            <MaskedInput
+              name="email"
+              mask={[
+                { regexp: /^[\w\-_.]+$/, placeholder: 'jdoe' },
+                { fixed: '@' },
+                { regexp: /^[\w]+$/, placeholder: 'hpe' },
+                { fixed: '.' },
+                { regexp: /^[\w]+$/, placeholder: 'com' },
+              ]}
+            />
+          </FormField>
+          <Box align="start">
+            <Button type="submit" label="Subscribe" primary />
+          </Box>
+        </Box>
+      </Form>
+    </Box>
+  );
+
+  const JoinConversation = () => (
+    <Box gap="medium">
+      <ChatOption size="large" />
+      <Text weight="bold" size="large">
+        Join the conversation
+      </Text>
+      <SubsectionText>
+        Specific questions? Want feedback or advice? Generally curious? Join
+        Slack with and HPE email address to be automatically added to
+        #general-hpe.
+      </SubsectionText>
+      <Box align="start">
+        <Button
+          label="Join us on Slack"
+          href="http://slackin.grommet.io/"
+          target="_blank"
+          rel="noreferrer noopener"
+          primary
+        />
+      </Box>
+    </Box>
+  );
+
+  const Contribute = () => (
+    <Box gap="medium">
+      <Github size="large" />
+      <Text weight="bold" size="large">
+        Contribute
+      </Text>
+      <SubsectionText>
+        Have suggestions? Improvement ideas? Submit a bug, feature request, or
+        better yet, make your impact for all by submitting your own
+        contribution.
+      </SubsectionText>
+      <Box align="start">
+        <Button
+          label="Submit to Github"
           href="https://github.com/hpe-design/aries/issues"
           target="_blank"
-          label="Open page in Github"
           rel="noreferrer noopener"
+          primary
         />
-      </Subsection>
-    </ContentSection>
+      </Box>
+    </Box>
+  );
+  return (
+    <>
+      <ContentSection lastSection>
+        <Subsection name="Still have questions?" level={2}>
+          <SubsectionText>
+            Something missing or looking for more information? Get in touch to
+            help make the HPE Design System better.
+          </SubsectionText>
+          <Box align="start">
+            <Button label="Leave feedback" onClick={onOpen} primary />
+          </Box>
+        </Subsection>
+      </ContentSection>
+      {open && (
+        <Layer position="center" modal onClickOutside={onClose} onEsc={onClose}>
+          <Box flex>
+            <Box
+              flex={false}
+              direction="row"
+              align="center"
+              justify="end"
+              pad={{ top: 'medium', horizontal: 'medium' }}
+            >
+              <Button icon={<Close />} onClick={onClose} />
+            </Box>
+            <Box
+              flex
+              pad={{ horizontal: 'large', bottom: 'large' }}
+              overflow="auto"
+            >
+              <Box flex={false}>
+                <Grid
+                  fill="horizontal"
+                  columns={
+                    size !== 'small' ? { count: 'fit', size: 'small' } : 'auto'
+                  }
+                  gap="large"
+                >
+                  <Subscribe />
+                  <JoinConversation />
+                  <Contribute />
+                </Grid>
+              </Box>
+            </Box>
+          </Box>
+        </Layer>
+      )}
+    </>
   );
 };

--- a/aries-site/src/components/content/SubmitFeedback.js
+++ b/aries-site/src/components/content/SubmitFeedback.js
@@ -16,7 +16,6 @@ const Subscribe = () => (
     </SubsectionText>
     <Box align="start">
       <Button
-        type="submit"
         label="Subscribe"
         // eslint-disable-next-line max-len
         href="mailto:mike.walrath@hpe.com?subject=Keep%20me%20updated%20on%20the%20HPE%20Design%20System&body=Hi%20there,%0d%0dI%20would%20like%20to%20be%20added%20to%20the%20HPE%20Design%20System%20mailing%20list,%20so%20that%20I'll%20receive%20updates%20and%20announcements%20about%20the%20Design%20System. Thank you!"
@@ -114,7 +113,11 @@ export const SubmitFeedback = () => {
               justify="end"
               pad={{ top: 'medium', horizontal: 'medium' }}
             >
-              <Button icon={<Close />} onClick={onClose} />
+              <Button
+                a11yTitle="Close Feedback Options"
+                icon={<Close />}
+                onClick={onClose}
+              />
             </Box>
             <Box
               flex

--- a/aries-site/src/components/content/SubmitFeedback.js
+++ b/aries-site/src/components/content/SubmitFeedback.js
@@ -1,21 +1,11 @@
-import React from 'react';
-import {
-  Box,
-  Button,
-  Form,
-  FormField,
-  Grid,
-  Layer,
-  MaskedInput,
-  ResponsiveContext,
-  Text,
-} from 'grommet';
+import React, { useContext, useState } from 'react';
+import { Box, Button, Grid, Layer, ResponsiveContext, Text } from 'grommet';
 import { ChatOption, MailOption, Close, Github } from 'grommet-icons';
 import { ContentSection, Subsection } from '../../layouts/content';
 import { SubsectionText } from '.';
 
-export const Subscribe = () => (
-  <Box gap="medium">
+const Subscribe = () => (
+  <Box gap="small">
     <MailOption size="large" />
     <Text weight="bold" size="large">
       Stay up-to-date
@@ -24,30 +14,20 @@ export const Subscribe = () => (
       Get the latest feature enhancements and announcements directly to your
       inbox.
     </SubsectionText>
-    <Form>
-      <Box gap="small">
-        <FormField margin="none">
-          <MaskedInput
-            name="email"
-            mask={[
-              { regexp: /^[\w\-_.]+$/, placeholder: 'jdoe' },
-              { fixed: '@' },
-              { regexp: /^[\w]+$/, placeholder: 'hpe' },
-              { fixed: '.' },
-              { regexp: /^[\w]+$/, placeholder: 'com' },
-            ]}
-          />
-        </FormField>
-        <Box align="start">
-          <Button type="submit" label="Subscribe" primary />
-        </Box>
-      </Box>
-    </Form>
+    <Box align="start">
+      <Button
+        type="submit"
+        label="Subscribe"
+        // eslint-disable-next-line max-len
+        href="mailto:mike.walrath@hpe.com?subject=Keep%20me%20updated%20on%20the%20HPE%20Design%20System&body=Hi%20there,%0d%0dI%20would%20like%20to%20be%20added%20to%20the%20HPE%20Design%20System%20mailing%20list,%20so%20that%20I'll%20receive%20updates%20and%20announcements%20about%20the%20Design%20System. Thank you!"
+        primary
+      />
+    </Box>
   </Box>
 );
 
-export const JoinConversation = () => (
-  <Box gap="medium">
+const JoinConversation = () => (
+  <Box gap="small">
     <ChatOption size="large" />
     <Text weight="bold" size="large">
       Join the conversation
@@ -68,8 +48,8 @@ export const JoinConversation = () => (
   </Box>
 );
 
-export const Contribute = () => (
-  <Box gap="medium">
+const Contribute = () => (
+  <Box gap="small">
     <Github size="large" />
     <Text weight="bold" size="large">
       Contribute
@@ -90,9 +70,24 @@ export const Contribute = () => (
   </Box>
 );
 
+export const FeedbackOptions = () => {
+  const size = useContext(ResponsiveContext);
+  return (
+    <Box flex={false} width="xlarge">
+      <Grid
+        columns={size !== 'small' ? { count: 'fit', size: 'small' } : 'auto'}
+        gap="large"
+      >
+        <Subscribe />
+        <JoinConversation />
+        <Contribute />
+      </Grid>
+    </Box>
+  );
+};
+
 export const SubmitFeedback = () => {
-  const size = React.useContext(ResponsiveContext);
-  const [open, setOpen] = React.useState();
+  const [open, setOpen] = useState();
   const onOpen = () => setOpen(true);
   const onClose = () => setOpen(undefined);
 
@@ -110,7 +105,7 @@ export const SubmitFeedback = () => {
         </Subsection>
       </ContentSection>
       {open && (
-        <Layer position="center" modal onClickOutside={onClose} onEsc={onClose}>
+        <Layer modal onClickOutside={onClose} onEsc={onClose} margin="medium">
           <Box flex>
             <Box
               flex={false}
@@ -126,19 +121,7 @@ export const SubmitFeedback = () => {
               pad={{ horizontal: 'large', bottom: 'large' }}
               overflow="auto"
             >
-              <Box flex={false}>
-                <Grid
-                  fill="horizontal"
-                  columns={
-                    size !== 'small' ? { count: 'fit', size: 'small' } : 'auto'
-                  }
-                  gap="large"
-                >
-                  <Subscribe />
-                  <JoinConversation />
-                  <Contribute />
-                </Grid>
-              </Box>
+              <FeedbackOptions />
             </Box>
           </Box>
         </Layer>

--- a/aries-site/src/components/content/SubmitFeedback.js
+++ b/aries-site/src/components/content/SubmitFeedback.js
@@ -32,8 +32,8 @@ const JoinConversation = () => (
       Join the conversation
     </Text>
     <SubsectionText>
-      Specific questions? Want feedback or advice? Generally curious? Join Slack
-      with and HPE email address to be automatically added to #general-hpe.
+      Specific questions? Want feedback or advice? Generally curious? Join the
+      #general-hpe channel on Grommet Slack by signing up with an HPE email.
     </SubsectionText>
     <Box align="start">
       <Button

--- a/aries-site/src/components/content/SubmitFeedback.js
+++ b/aries-site/src/components/content/SubmitFeedback.js
@@ -14,89 +14,88 @@ import { ChatOption, MailOption, Close, Github } from 'grommet-icons';
 import { ContentSection, Subsection } from '../../layouts/content';
 import { SubsectionText } from '.';
 
+export const Subscribe = () => (
+  <Box gap="medium">
+    <MailOption size="large" />
+    <Text weight="bold" size="large">
+      Stay up-to-date
+    </Text>
+    <SubsectionText>
+      Get the latest feature enhancements and announcements directly to your
+      inbox.
+    </SubsectionText>
+    <Form>
+      <Box gap="small">
+        <FormField margin="none">
+          <MaskedInput
+            name="email"
+            mask={[
+              { regexp: /^[\w\-_.]+$/, placeholder: 'jdoe' },
+              { fixed: '@' },
+              { regexp: /^[\w]+$/, placeholder: 'hpe' },
+              { fixed: '.' },
+              { regexp: /^[\w]+$/, placeholder: 'com' },
+            ]}
+          />
+        </FormField>
+        <Box align="start">
+          <Button type="submit" label="Subscribe" primary />
+        </Box>
+      </Box>
+    </Form>
+  </Box>
+);
+
+export const JoinConversation = () => (
+  <Box gap="medium">
+    <ChatOption size="large" />
+    <Text weight="bold" size="large">
+      Join the conversation
+    </Text>
+    <SubsectionText>
+      Specific questions? Want feedback or advice? Generally curious? Join Slack
+      with and HPE email address to be automatically added to #general-hpe.
+    </SubsectionText>
+    <Box align="start">
+      <Button
+        label="Join us on Slack"
+        href="http://slackin.grommet.io/"
+        target="_blank"
+        rel="noreferrer noopener"
+        primary
+      />
+    </Box>
+  </Box>
+);
+
+export const Contribute = () => (
+  <Box gap="medium">
+    <Github size="large" />
+    <Text weight="bold" size="large">
+      Contribute
+    </Text>
+    <SubsectionText>
+      Have suggestions? Improvement ideas? Submit a bug, feature request, or
+      better yet, make your impact for all by submitting your own contribution.
+    </SubsectionText>
+    <Box align="start">
+      <Button
+        label="Submit to Github"
+        href="https://github.com/hpe-design/aries/issues"
+        target="_blank"
+        rel="noreferrer noopener"
+        primary
+      />
+    </Box>
+  </Box>
+);
+
 export const SubmitFeedback = () => {
   const size = React.useContext(ResponsiveContext);
   const [open, setOpen] = React.useState();
   const onOpen = () => setOpen(true);
   const onClose = () => setOpen(undefined);
 
-  const Subscribe = () => (
-    <Box gap="medium">
-      <MailOption size="large" />
-      <Text weight="bold" size="large">
-        Stay up-to-date
-      </Text>
-      <SubsectionText>
-        Get the latest feature enhancements and announcements directly to your
-        inbox.
-      </SubsectionText>
-      <Form>
-        <Box gap="small">
-          <FormField margin="none">
-            <MaskedInput
-              name="email"
-              mask={[
-                { regexp: /^[\w\-_.]+$/, placeholder: 'jdoe' },
-                { fixed: '@' },
-                { regexp: /^[\w]+$/, placeholder: 'hpe' },
-                { fixed: '.' },
-                { regexp: /^[\w]+$/, placeholder: 'com' },
-              ]}
-            />
-          </FormField>
-          <Box align="start">
-            <Button type="submit" label="Subscribe" primary />
-          </Box>
-        </Box>
-      </Form>
-    </Box>
-  );
-
-  const JoinConversation = () => (
-    <Box gap="medium">
-      <ChatOption size="large" />
-      <Text weight="bold" size="large">
-        Join the conversation
-      </Text>
-      <SubsectionText>
-        Specific questions? Want feedback or advice? Generally curious? Join
-        Slack with and HPE email address to be automatically added to
-        #general-hpe.
-      </SubsectionText>
-      <Box align="start">
-        <Button
-          label="Join us on Slack"
-          href="http://slackin.grommet.io/"
-          target="_blank"
-          rel="noreferrer noopener"
-          primary
-        />
-      </Box>
-    </Box>
-  );
-
-  const Contribute = () => (
-    <Box gap="medium">
-      <Github size="large" />
-      <Text weight="bold" size="large">
-        Contribute
-      </Text>
-      <SubsectionText>
-        Have suggestions? Improvement ideas? Submit a bug, feature request, or
-        better yet, make your impact for all by submitting your own
-        contribution.
-      </SubsectionText>
-      <Box align="start">
-        <Button
-          label="Submit to Github"
-          href="https://github.com/hpe-design/aries/issues"
-          target="_blank"
-          rel="noreferrer noopener"
-          primary
-        />
-      </Box>
-    </Box>
-  );
   return (
     <>
       <ContentSection lastSection>

--- a/aries-site/src/data/structure.js
+++ b/aries-site/src/data/structure.js
@@ -36,6 +36,12 @@ export const structure = [
     ],
   },
   {
+    name: 'Feedback',
+    seoDescription:
+      'Something missing or looking for more information? Get in touch to help make the HPE Design System better.',
+    pages: [],
+  },
+  {
     name: 'Guidelines',
     color: 'green',
     description:

--- a/aries-site/src/layouts/main/Footer.js
+++ b/aries-site/src/layouts/main/Footer.js
@@ -1,6 +1,7 @@
 import React, { useContext } from 'react';
 import { NavLink } from 'aries-core';
 import { Box, Footer as GrommetFooter, ResponsiveContext, Text } from 'grommet';
+import { nameToPath } from '../../utils';
 
 export const Footer = () => {
   const size = useContext(ResponsiveContext);
@@ -39,12 +40,7 @@ export const Footer = () => {
           target="_blank"
           rel="noreferrer noopener"
         />
-        <NavLink
-          label="Feedback"
-          href="https://github.com/hpe-design/aries/issues"
-          target="_blank"
-          rel="noreferrer noopener"
-        />
+        <NavLink label="Feedback" href={nameToPath('Feedback')} />
       </Box>
     </GrommetFooter>
   );

--- a/aries-site/src/layouts/main/Footer.js
+++ b/aries-site/src/layouts/main/Footer.js
@@ -1,4 +1,5 @@
 import React, { useContext } from 'react';
+import Link from 'next/link';
 import { NavLink } from 'aries-core';
 import { Box, Footer as GrommetFooter, ResponsiveContext, Text } from 'grommet';
 import { nameToPath } from '../../utils';
@@ -40,7 +41,11 @@ export const Footer = () => {
           target="_blank"
           rel="noreferrer noopener"
         />
-        <NavLink label="Feedback" href={nameToPath('Feedback')} />
+        {/* Need to pass href because of:
+        https://github.com/zeit/next.js/#forcing-the-link-to-expose-href-to-its-child */}
+        <Link href={nameToPath('Feedback')} passHref>
+          <NavLink label="Feedback" />
+        </Link>
       </Box>
     </GrommetFooter>
   );

--- a/aries-site/src/pages/feedback.js
+++ b/aries-site/src/pages/feedback.js
@@ -1,0 +1,50 @@
+import React from 'react';
+
+import { Box, Grid, ResponsiveContext } from 'grommet';
+import { Layout, ContentSection, Subsection } from '../layouts';
+import {
+  Meta,
+  Subscribe,
+  JoinConversation,
+  Contribute,
+  SubsectionText,
+} from '../components';
+import { getPageDetails } from '../utils';
+
+const title = 'Feedback';
+const page = getPageDetails(title);
+
+const Feedback = () => {
+  const size = React.useContext(ResponsiveContext);
+  return (
+    <Layout title={title} isLanding>
+      <Meta
+        title={title}
+        description={page.seoDescription}
+        canonicalUrl="https://design-system.hpe.design/feedback"
+      />
+      <ContentSection lastSection>
+        <Subsection name="Have feedback to share?" level={2}>
+          <SubsectionText>
+            Get in touch to help make the HPE Design System better.
+          </SubsectionText>
+        </Subsection>
+        <Box flex={false}>
+          <Grid
+            fill="horizontal"
+            columns={
+              size !== 'small' ? { count: 'fit', size: 'small' } : 'auto'
+            }
+            gap="large"
+          >
+            <Subscribe />
+            <JoinConversation />
+            <Contribute />
+          </Grid>
+        </Box>
+      </ContentSection>
+    </Layout>
+  );
+};
+
+export default Feedback;

--- a/aries-site/src/pages/feedback.js
+++ b/aries-site/src/pages/feedback.js
@@ -1,21 +1,14 @@
 import React from 'react';
 
-import { Box, Grid, ResponsiveContext } from 'grommet';
-import { Layout, ContentSection, Subsection } from '../layouts';
-import {
-  Meta,
-  Subscribe,
-  JoinConversation,
-  Contribute,
-  SubsectionText,
-} from '../components';
+import { Box } from 'grommet';
+import { Layout, Subsection } from '../layouts';
+import { Meta, FeedbackOptions, SubsectionText } from '../components';
 import { getPageDetails } from '../utils';
 
 const title = 'Feedback';
 const page = getPageDetails(title);
 
 const Feedback = () => {
-  const size = React.useContext(ResponsiveContext);
   return (
     <Layout title={title} isLanding>
       <Meta
@@ -23,26 +16,14 @@ const Feedback = () => {
         description={page.seoDescription}
         canonicalUrl="https://design-system.hpe.design/feedback"
       />
-      <ContentSection lastSection>
+      <Box gap="medium">
         <Subsection name="Have feedback to share?" level={2}>
           <SubsectionText>
             Get in touch to help make the HPE Design System better.
           </SubsectionText>
         </Subsection>
-        <Box flex={false}>
-          <Grid
-            fill="horizontal"
-            columns={
-              size !== 'small' ? { count: 'fit', size: 'small' } : 'auto'
-            }
-            gap="large"
-          >
-            <Subscribe />
-            <JoinConversation />
-            <Contribute />
-          </Grid>
-        </Box>
-      </ContentSection>
+        <FeedbackOptions />
+      </Box>
     </Layout>
   );
 };

--- a/aries-site/src/tests/navigation/search.js
+++ b/aries-site/src/tests/navigation/search.js
@@ -1,11 +1,11 @@
 /* eslint-disable no-undef */
 import { ReactSelector, waitForReact } from 'testcafe-react-selectors';
-import { 
+import {
   baseUrl,
   getLocation,
   repeatKeyPress,
   Search,
-  getSuggestion, 
+  getSuggestion,
 } from '../utils';
 
 fixture('Search')
@@ -14,66 +14,78 @@ fixture('Search')
     await waitForReact();
   });
 
-test('should navigate to correct page after user types'
-+ 'and clicks suggestion with mouse', async t => {
-  const page = 'Develop';
-  const expectedPath = `${baseUrl}/${page.toLowerCase()}`;
-  const suggestion = getSuggestion(page);
-  await t
-    .typeText(ReactSelector(Search), 'dev')
-    .click(suggestion)
-    .expect(getLocation())
-    .eql(expectedPath);
-});
+test(
+  'should navigate to correct page after user types ' +
+    'and clicks suggestion with mouse',
+  async t => {
+    const page = 'Develop';
+    const expectedPath = `${baseUrl}/${page.toLowerCase()}`;
+    const suggestion = getSuggestion(page);
+    await t
+      .typeText(ReactSelector(Search), 'dev')
+      .click(suggestion)
+      .expect(getLocation())
+      .eql(expectedPath);
+  },
+);
 
-test('should navigate to correct page after user'
-+ 'types page name and hits enter', async t => {
-  const page = 'Foundation';
-  const expectedPath = `${baseUrl}/${page.toLowerCase()}`;
+test(
+  'should navigate to correct page after user ' +
+    'types page name and hits enter',
+  async t => {
+    const page = 'Foundation';
+    const expectedPath = `${baseUrl}/${page.toLowerCase()}`;
 
-  await t
-    .typeText(ReactSelector(Search), page)
-    .pressKey('enter')
-    .expect(getLocation())
-    .eql(expectedPath);
-});
+    await t
+      .typeText(ReactSelector(Search), page)
+      .pressKey('enter')
+      .expect(getLocation())
+      .eql(expectedPath);
+  },
+);
 
-test('should navigate to correct hash after user clicks a'
-+ 'suggestion that leads to a page subsection', async t => {
-  const expectedPath = '/foundation/color#background-colors';
-  const page = 'Background Colors';
-  const suggestion = getSuggestion(page);
+test(
+  'should navigate to correct hash after user clicks a ' +
+    'suggestion that leads to a page subsection',
+  async t => {
+    const expectedPath = '/foundation/color#background-colors';
+    const page = 'Background Colors';
+    const suggestion = getSuggestion(page);
 
-  await t
-    .typeText(ReactSelector(Search), 'col')
-    .click(suggestion)
-    .expect(getLocation())
-    .eql(baseUrl + expectedPath);
-});
+    await t
+      .typeText(ReactSelector(Search), 'col')
+      .click(suggestion)
+      .expect(getLocation())
+      .eql(baseUrl + expectedPath);
+  },
+);
 
-test('should navigate to correct page'
-+ 'when user is only using keyboard ', async t => {
-  const page = 'Aruba Logo';
-  const expectedPath = '/foundation/branding#aruba-logo';
-  const search = ReactSelector(`${Search} Search__StyledTextInput`);
+test(
+  'should navigate to correct page ' + 'when user is only using keyboard ',
+  async t => {
+    const page = 'Aruba Logo';
+    const expectedPath = '/foundation/branding#aruba-logo';
 
-  await t
-    // theme toggle --> hpe button --> search
-    .pressKey(await repeatKeyPress('tab', 3))
-    // start typing for something
-    .pressKey('a');
+    await t
+      // theme toggle --> hpe button --> search
+      .pressKey(await repeatKeyPress('tab', 3))
+      // start typing for something
+      .pressKey('a');
 
-  // find how many times to press down arrow key to get to suggestion
-  const suggestions = await search.getReact(({ props }) => props.suggestions);
-  let count;
-  suggestions.forEach((suggestion, index) =>
-    // add one since array index starts at 0
-    suggestion === page ? (count = index + 1) : undefined,
-  );
+    // find how many times to press down arrow key to get to suggestion
+    const suggestions = await ReactSelector(Search).getReact(
+      ({ props }) => props.suggestions,
+    );
+    let count;
+    suggestions.forEach((suggestion, index) =>
+      // add one since array index starts at 0
+      suggestion === page ? (count = index + 1) : undefined,
+    );
 
-  await t
-    .pressKey(await repeatKeyPress('down', count))
-    .pressKey('enter')
-    .expect(getLocation())
-    .eql(baseUrl + expectedPath);
-});
+    await t
+      .pressKey(await repeatKeyPress('down', count))
+      .pressKey('enter')
+      .expect(getLocation())
+      .eql(baseUrl + expectedPath);
+  },
+);

--- a/aries-site/src/tests/utils.js
+++ b/aries-site/src/tests/utils.js
@@ -4,7 +4,7 @@ import { ReactSelector } from 'testcafe-react-selectors';
 export const baseUrl = 'http://localhost:3030';
 
 // Selector name found using Chrome React dev tools on prod mode of website
-export const Search = 'D Box';
+export const Search = 'Search__StyledTextInput';
 
 export const getLocation = ClientFunction(() => document.location.href);
 


### PR DESCRIPTION
One approach to the feedback options proposed here:
- https://designer.grommet.io/?id=design-system-feedback-eric-soderberg-hpe-com
- https://docs.google.com/document/d/1spSsKk3nkift8iwFG5i8QHE1V-6BY1q4YUoYRMW220w/edit

Having all of the options live inline on the page felt expansive but jumping to a completely new page felt unwanted if I was still interested in consuming the content on the page I was on.

The subscribe button has not been linked up yet, this will require some more digging into -- depending on timing this week this section could be changed to a simple 'mailto:' for now.