### PR TITLE
Form template infrastructure and first example

### DIFF
--- a/aries-site/src/data/structure.js
+++ b/aries-site/src/data/structure.js
@@ -258,6 +258,6 @@ export const structure = [
       'Common form use cases from application configuration to payment acceptance.',
     icon: size => <IconBrand size={size} />,
     seoDescription: 'HPE Design System form examples and templates.',
-    sections: [],
+    sections: ['Sign In', 'Sign Up'],
   },
 ];

--- a/aries-site/src/data/structure.js
+++ b/aries-site/src/data/structure.js
@@ -69,7 +69,7 @@ export const structure = [
     icon: size => <IconTemplates size={size} />,
     seoDescription:
       'HPE Design System starter templates for jumpstarting application screen design and development.',
-    pages: ['Dashboards', 'List Views'],
+    pages: ['Dashboards', 'Forms', 'List Views'],
   },
   {
     name: 'Components',
@@ -250,6 +250,14 @@ export const structure = [
     icon: size => <IconBrand size={size} />,
     seoDescription:
       'HPE Design System template for providing a list of information.',
+    sections: [],
+  },
+  {
+    name: 'Forms',
+    description:
+      'Common form use cases from application configuration to payment acceptance.',
+    icon: size => <IconBrand size={size} />,
+    seoDescription: 'HPE Design System form examples and templates.',
     sections: [],
   },
 ];

--- a/aries-site/src/examples/templates/forms/FormContainer.js
+++ b/aries-site/src/examples/templates/forms/FormContainer.js
@@ -1,0 +1,20 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Tile } from 'aries-core';
+
+export const FormContainer = ({ children, ...rest }) => {
+  return (
+    <Tile
+      background="background-front"
+      border
+      pad={{ horizontal: 'medium', vertical: 'medium' }}
+      {...rest}
+    >
+      {children}
+    </Tile>
+  );
+};
+
+FormContainer.propTypes = {
+  children: PropTypes.node,
+};

--- a/aries-site/src/examples/templates/forms/SignInExample.js
+++ b/aries-site/src/examples/templates/forms/SignInExample.js
@@ -63,6 +63,7 @@ const ResetPassword = ({ closeLayer, email }) => {
             <FormField
               label="Email"
               htmlFor="resetEmail"
+              name="resetEmail"
               validate={emailValidation}
             >
               <TextInput

--- a/aries-site/src/examples/templates/forms/SignInExample.js
+++ b/aries-site/src/examples/templates/forms/SignInExample.js
@@ -55,16 +55,20 @@ const ResetPassword = ({ closeLayer, email }) => {
           onChange={setFormValues}
           onSubmit={({ value, touched }) => onSubmit({ value, touched })}
         >
-          <Text>A password reset email will be sent to </Text>
-          <FormField
-            label="Email"
-            name="resetEmail"
-            component={TextInput}
-            type="email"
-            placeholder="your.email@company.com"
-            validate={emailValidation}
-          />
-          <Button label="Send Password Reset" primary type="submit" />
+          <Box gap="medium">
+            <Text>
+              An email to reset your password will be sent to the following
+              address:
+            </Text>
+            <FormField
+              name="resetEmail"
+              component={TextInput}
+              type="email"
+              placeholder="your.email@company.com"
+              validate={emailValidation}
+            />
+            <Button label="Send Password Reset" primary type="submit" />
+          </Box>
         </Form>
       </Box>
     </>

--- a/aries-site/src/examples/templates/forms/SignInExample.js
+++ b/aries-site/src/examples/templates/forms/SignInExample.js
@@ -61,12 +61,17 @@ const ResetPassword = ({ closeLayer, email }) => {
               address:
             </Text>
             <FormField
-              name="resetEmail"
-              component={TextInput}
-              type="email"
-              placeholder="your.email@company.com"
+              label="Email"
+              htmlFor="resetEmail"
               validate={emailValidation}
-            />
+            >
+              <TextInput
+                id="resetEmail"
+                name="resetEmail"
+                type="email"
+                placeholder="your.email@company.com"
+              />
+            </FormField>
             <Button label="Send Password Reset" primary type="submit" />
           </Box>
         </Form>
@@ -117,20 +122,30 @@ export const SignInExample = () => {
             onSubmit={({ value, touched }) => onSubmit({ value, touched })}
           >
             <FormField
-              name="email"
               label="Email"
-              component={TextInput}
-              placeholder="james@hpe.com"
-              type="email"
+              name="email"
+              htmlFor="email-sign-in"
               validate={emailValidation}
-            />
+            >
+              <TextInput
+                id="email-sign-in"
+                name="email"
+                placeholder="james@hpe.com"
+                type="email"
+              />
+            </FormField>
             <FormField
-              name="password"
               label="Password"
-              component={TextInput}
-              placeholder="•••••••••••••••"
-              type="password"
-            />
+              htmlFor="password-sign-in"
+              name="password"
+            >
+              <TextInput
+                id="password-sign-in"
+                name="password"
+                placeholder="•••••••••••••••"
+                type="password"
+              />
+            </FormField>
             <CheckBox name="termsAndPrivacy" label="Remember me" />
             <Box align="start" margin={{ top: 'medium', bottom: 'small' }}>
               <Button

--- a/aries-site/src/examples/templates/forms/SignInExample.js
+++ b/aries-site/src/examples/templates/forms/SignInExample.js
@@ -1,0 +1,171 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import {
+  Box,
+  Button,
+  CheckBox,
+  Form,
+  FormField,
+  Header,
+  Heading,
+  Layer,
+  Main,
+  Text,
+  TextInput,
+} from 'grommet';
+import { Close, Next } from 'grommet-icons';
+
+import { FormContainer } from '.';
+import { emailValidation } from './formHelpers';
+
+const ResetPassword = ({ closeLayer, email }) => {
+  const [formValues, setFormValues] = React.useState({ resetEmail: email });
+
+  // eslint-disable-next-line no-unused-vars
+  const onSubmit = ({ value, touched }) => {
+    // Your password reset logic here
+    // Display success status
+    closeLayer();
+  };
+
+  return (
+    <>
+      <Box
+        direction="row"
+        justify="end"
+        pad={{ horizontal: 'small', top: 'small' }}
+      >
+        <Button
+          a11yTitle="Close reset password form"
+          icon={<Close />}
+          onClick={closeLayer}
+        />
+      </Box>
+      <Box
+        gap="medium"
+        margin={{ horizontal: 'xlarge', bottom: 'xlarge', top: 'large' }}
+        width="medium"
+      >
+        <Heading level={2} margin="none">
+          Reset Password
+        </Heading>
+        <Form
+          validate="blur"
+          value={formValues}
+          onChange={setFormValues}
+          onSubmit={({ value, touched }) => onSubmit({ value, touched })}
+        >
+          <Text>A password reset email will be sent to </Text>
+          <FormField
+            label="Email"
+            name="resetEmail"
+            component={TextInput}
+            type="email"
+            placeholder="your.email@company.com"
+            validate={emailValidation}
+          />
+          <Button label="Send Password Reset" primary type="submit" />
+        </Form>
+      </Box>
+    </>
+  );
+};
+
+export const SignInExample = () => {
+  const [formValues, setFormValues] = React.useState({});
+  const [showForgotPassword, setShowForgotPassword] = React.useState(false);
+
+  const onClose = () => {
+    setShowForgotPassword(false);
+  };
+
+  const onForgotPassword = () => {
+    setShowForgotPassword(true);
+  };
+
+  // eslint-disable-next-line no-unused-vars
+  const onSubmit = ({ value, touched }) => {
+    // Your submission logic here
+  };
+
+  return (
+    <FormContainer width="medium">
+      <Box gap="medium">
+        <Header
+          direction="column"
+          align="start"
+          gap="xxsmall"
+          pad={{ horizontal: 'xxsmall' }}
+        >
+          <Heading level={3} margin="none">
+            Sign In
+          </Heading>
+          <Text>to Hewlett Packard Enterprise</Text>
+        </Header>
+        <Main
+          // Padding used to prevent focus from being cutoff
+          pad={{ horizontal: 'xxsmall' }}
+        >
+          <Form
+            validate="blur"
+            value={formValues}
+            onChange={setFormValues}
+            onSubmit={({ value, touched }) => onSubmit({ value, touched })}
+          >
+            <FormField
+              name="email"
+              label="Email"
+              component={TextInput}
+              placeholder="james@hpe.com"
+              type="email"
+              validate={emailValidation}
+            />
+            <FormField
+              name="password"
+              label="Password"
+              component={TextInput}
+              placeholder="•••••••••••••••"
+              type="password"
+            />
+            <CheckBox name="termsAndPrivacy" label="Remember me" />
+            <Box align="start" margin={{ top: 'medium', bottom: 'small' }}>
+              <Button
+                label="Sign in"
+                icon={<Next />}
+                reverse
+                primary
+                type="submit"
+              />
+            </Box>
+          </Form>
+          <Box align="start" margin={{ top: 'medium', bottom: 'small' }}>
+            <Button
+              label={
+                <Text weight={600} style={{ textDecoration: 'underline' }}>
+                  Forgot Password?
+                </Text>
+              }
+              onClick={onForgotPassword}
+              color="brand"
+              plain
+            />
+            {showForgotPassword && (
+              <Layer modal onClickOutside={onClose} onEsc={onClose}>
+                <ResetPassword
+                  closeLayer={onClose}
+                  email={formValues.email}
+                  updateForm={setFormValues}
+                />
+              </Layer>
+            )}
+          </Box>
+        </Main>
+      </Box>
+    </FormContainer>
+  );
+};
+
+ResetPassword.propTypes = {
+  closeLayer: PropTypes.func,
+  email: PropTypes.string,
+};

--- a/aries-site/src/examples/templates/forms/SignUpExample.js
+++ b/aries-site/src/examples/templates/forms/SignUpExample.js
@@ -52,27 +52,48 @@ export const SignUpExample = () => {
             onSubmit={({ value, touched }) => onSubmit({ value, touched })}
           >
             <FormField
-              name="email"
               label="Email"
-              component={MaskedInput}
-              type="email"
-              mask={emailMask}
+              htmlFor="email-sign-up"
+              name="email"
               validate={emailValidation}
-            />
+            >
+              <MaskedInput
+                id="email-sign-up"
+                name="email"
+                mask={emailMask}
+                type="email"
+              />
+            </FormField>
             <FormField
-              name="fullName"
               label="Full Name"
-              component={TextInput}
-              placeholder="Jane Smith"
-            />
+              htmlFor="fullName-sign-up"
+              name="fullName"
+            >
+              <TextInput
+                id="fullName-sign-up"
+                name="fullName"
+                placeholder="Jane Smith"
+              />
+            </FormField>
             <FormField
-              name="password"
               label="Password"
-              component={TextInput}
-              type="password"
-              placeholder="•••••••••••••••"
+              htmlFor="password-sign-up"
+              name="password"
+              help={
+                <Text size="xsmall">
+                  Include at least 8 characters, a lowercase letter, an
+                  uppercase letter, a number, and a special character
+                </Text>
+              }
               validate={passwordValidation}
-            />
+            >
+              <TextInput
+                id="password-sign-up"
+                name="password"
+                placeholder="•••••••••••••••"
+                type="password"
+              />
+            </FormField>
             <CheckBox
               name="termsAndPrivacy"
               label={

--- a/aries-site/src/examples/templates/forms/SignUpExample.js
+++ b/aries-site/src/examples/templates/forms/SignUpExample.js
@@ -1,0 +1,107 @@
+import React from 'react';
+import {
+  Anchor,
+  Box,
+  Button,
+  CheckBox,
+  Form,
+  FormField,
+  Header,
+  Heading,
+  Main,
+  MaskedInput,
+  Text,
+  TextInput,
+} from 'grommet';
+
+import { FormContainer } from '.';
+import { emailMask, emailValidation, passwordValidation } from './formHelpers';
+
+export const SignUpExample = () => {
+  const [formValues, setFormValues] = React.useState({
+    email: 'jane.smith@hpe.com',
+  });
+
+  // eslint-disable-next-line no-unused-vars
+  const onSubmit = ({ value, touched }) => {
+    // Your submission logic here
+  };
+
+  return (
+    <FormContainer width="medium">
+      <Box gap="medium">
+        <Header
+          direction="column"
+          align="start"
+          gap="xxsmall"
+          pad={{ horizontal: 'xxsmall' }}
+        >
+          <Heading level={3} margin="none">
+            Sign Up
+          </Heading>
+          <Text>for a Hewlett Packard Enterprise account</Text>
+        </Header>
+        <Main
+          // Padding used to prevent focus from being cutoff
+          pad={{ horizontal: 'xxsmall' }}
+        >
+          <Form
+            validate="blur"
+            value={formValues}
+            onChange={setFormValues}
+            onSubmit={({ value, touched }) => onSubmit({ value, touched })}
+          >
+            <FormField
+              name="email"
+              label="Email"
+              component={MaskedInput}
+              type="email"
+              mask={emailMask}
+              validate={emailValidation}
+            />
+            <FormField
+              name="fullName"
+              label="Full Name"
+              component={TextInput}
+              placeholder="Jane Smith"
+            />
+            <FormField
+              name="password"
+              label="Password"
+              component={TextInput}
+              type="password"
+              placeholder="•••••••••••••••"
+              validate={passwordValidation}
+            />
+            <CheckBox
+              name="termsAndPrivacy"
+              label={
+                <Text>
+                  I accept the HPE{' '}
+                  <Anchor
+                    label="Terms of Use"
+                    href="#"
+                    target="_blank"
+                    rel="noreferrer noopener"
+                    color="blue!"
+                  />{' '}
+                  and{' '}
+                  <Anchor
+                    label="Privacy Policy"
+                    href="#"
+                    target="_blank"
+                    rel="noreferrer noopener"
+                    color="blue!"
+                  />
+                </Text>
+              }
+            />
+            <Box align="start" margin={{ top: 'medium', bottom: 'small' }}>
+              <Button label="Sign up" primary type="submit" />
+            </Box>
+          </Form>
+        </Main>
+      </Box>
+    </FormContainer>
+  );
+};

--- a/aries-site/src/examples/templates/forms/formHelpers.js
+++ b/aries-site/src/examples/templates/forms/formHelpers.js
@@ -1,0 +1,62 @@
+export const emailMask = [
+  {
+    regexp: /^[\w\-_.]+$/,
+    placeholder: 'jane.smith',
+  },
+  { fixed: '@' },
+  {
+    regexp: /^[\w]+$/,
+    placeholder: 'hpe',
+  },
+  { fixed: '.' },
+  {
+    regexp: /^[\w]+$/,
+    placeholder: 'com',
+  },
+];
+
+export const emailValidation = [
+  {
+    regexp: new RegExp('[^@ \\t\\r\\n]+@'),
+    message: 'Missing an @?',
+    status: 'info',
+  },
+  {
+    regexp: new RegExp('[^@ \\t\\r\\n]+@[^@ \\t\\r\\n]+\\.[^@ \\t\\r\\n]+'),
+    message: 'Missing an .?',
+    status: 'info',
+  },
+  {
+    regexp: new RegExp('[^@ \\t\\r\\n]+@[^@ \\t\\r\\n]+\\.[^@ \\t\\r\\n]+'),
+    message: "Email address doesn't look quite right",
+    status: 'error',
+  },
+];
+
+export const passwordValidation = [
+  {
+    regexp: new RegExp('(?=.*?[A-Z])'),
+    message: 'At least one uppercase English letter',
+    status: 'error',
+  },
+  {
+    regexp: new RegExp('(?=.*?[a-z])'),
+    message: 'At least one lowercase English letter',
+    status: 'error',
+  },
+  {
+    regexp: new RegExp('(?=.*?[0-9])'),
+    message: 'At least one number',
+    status: 'error',
+  },
+  {
+    regexp: new RegExp('(?=.*?[#?!@$ %^&*-])'),
+    message: 'At least one special character or space',
+    status: 'error',
+  },
+  {
+    regexp: new RegExp('.{8,}'),
+    message: 'At least eight characters',
+    status: 'error',
+  },
+];

--- a/aries-site/src/examples/templates/forms/index.js
+++ b/aries-site/src/examples/templates/forms/index.js
@@ -1,3 +1,4 @@
 export * from './FormContainer';
 export * from './formHelpers';
+export * from './SignInExample';
 export * from './SignUpExample';

--- a/aries-site/src/examples/templates/forms/index.js
+++ b/aries-site/src/examples/templates/forms/index.js
@@ -1,0 +1,3 @@
+export * from './FormContainer';
+export * from './formHelpers';
+export * from './SignUpExample';

--- a/aries-site/src/examples/templates/index.js
+++ b/aries-site/src/examples/templates/index.js
@@ -1,5 +1,6 @@
 export * from './AppHeaderExample';
 export * from './dashboards';
+export * from './forms';
 export * from './list-views';
 export * from './PageHeaderExample';
 export * from './ScreenContainer';

--- a/aries-site/src/pages/templates/forms.js
+++ b/aries-site/src/pages/templates/forms.js
@@ -1,0 +1,41 @@
+import React from 'react';
+import { Meta, SubsectionText } from '../../components';
+import { SignUpExample } from '../../examples';
+import { ContentSection, Example, Layout, Subsection } from '../../layouts';
+import { getPageDetails } from '../../utils';
+
+const title = 'Forms';
+const topic = 'Templates';
+const page = getPageDetails(title);
+
+const Forms = () => {
+  return (
+    <Layout title={title}>
+      <Meta
+        title={title}
+        description={page.seoDescription}
+        canonicalUrl="https://design-system.hpe.design/templates/forms"
+      />
+      <ContentSection>
+        <Subsection name={title} level={1} topic={topic}>
+          <SubsectionText>
+            Template patterns for common form use cases, from application
+            configurations to payment acceptance for the latest as-a-service
+            product offerings.
+          </SubsectionText>
+        </Subsection>
+      </ContentSection>
+      <ContentSection>
+        <Subsection name="Sign Up">
+          <Example
+            code="https://raw.githubusercontent.com/hpe-design/design-system/master/aries-site/src/templates/forms/SignUpExample.js"
+            figma="https://www.figma.com/file/K0PppsSh6aQSszqlwKAekg/hpe-design-system-stickers?node-id=259%3A86"
+          >
+            <SignUpExample />
+          </Example>
+        </Subsection>
+      </ContentSection>
+    </Layout>
+  );
+};
+export default Forms;

--- a/aries-site/src/pages/templates/forms.js
+++ b/aries-site/src/pages/templates/forms.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Meta, SubsectionText } from '../../components';
-import { SignUpExample } from '../../examples';
+import { SignInExample, SignUpExample } from '../../examples';
 import { ContentSection, Example, Layout, Subsection } from '../../layouts';
 import { getPageDetails } from '../../utils';
 
@@ -32,6 +32,16 @@ const Forms = () => {
             figma="https://www.figma.com/file/K0PppsSh6aQSszqlwKAekg/hpe-design-system-stickers?node-id=259%3A86"
           >
             <SignUpExample />
+          </Example>
+        </Subsection>
+      </ContentSection>
+      <ContentSection>
+        <Subsection name="Sign Up">
+          <Example
+            code="https://raw.githubusercontent.com/hpe-design/design-system/master/aries-site/src/templates/forms/SignInExampe.js"
+            figma="https://www.figma.com/file/K0PppsSh6aQSszqlwKAekg/hpe-design-system-stickers?node-id=259%3A86"
+          >
+            <SignInExample />
           </Example>
         </Subsection>
       </ContentSection>

--- a/aries-site/src/pages/templates/forms.js
+++ b/aries-site/src/pages/templates/forms.js
@@ -36,10 +36,10 @@ const Forms = () => {
         </Subsection>
       </ContentSection>
       <ContentSection>
-        <Subsection name="Sign Up">
+        <Subsection name="Sign In">
           <Example
             code="https://raw.githubusercontent.com/hpe-design/design-system/master/aries-site/src/templates/forms/SignInExampe.js"
-            figma="https://www.figma.com/file/K0PppsSh6aQSszqlwKAekg/hpe-design-system-stickers?node-id=259%3A86"
+            figma="https://www.figma.com/file/K0PppsSh6aQSszqlwKAekg/hpe-design-system-stickers?node-id=242%3A28"
           >
             <SignInExample />
           </Example>

--- a/aries-site/src/pages/templates/forms.js
+++ b/aries-site/src/pages/templates/forms.js
@@ -1,4 +1,5 @@
 import React from 'react';
+
 import { Meta, SubsectionText } from '../../components';
 import { SignInExample, SignUpExample } from '../../examples';
 import { ContentSection, Example, Layout, Subsection } from '../../layouts';


### PR DESCRIPTION
Related Issue: https://github.com/hpe-design/design-system/issues/412

Work Included:

- Added forms section to templates page
- Added forms page
- Added Signup Example
- Initial form field validation rules

Review Resources:
- [Figma](https://www.figma.com/file/K0PppsSh6aQSszqlwKAekg/hpe-design-system-stickers?node-id=259%3A86)
- [Preview - Forms Section](https://deploy-preview-432--keen-mayer-a86c8b.netlify.com/templates/forms)
- [Preview - Signup Example](https://deploy-preview-432--keen-mayer-a86c8b.netlify.com/templates/forms#sign-up)

**Screen Shots**
![Screen Shot 2020-02-28 at 9 10 06 AM](https://user-images.githubusercontent.com/1756948/75564863-2aa74700-5a0a-11ea-9138-525f2b1dd63a.png)


![Screen Shot 2020-02-28 at 9 10 18 AM](https://user-images.githubusercontent.com/1756948/75564866-2ed36480-5a0a-11ea-976d-f54d98d829c6.png)
 