### PR TITLE
Form SettingsExample Pattern

### DIFF
--- a/aries-site/src/data/structure.js
+++ b/aries-site/src/data/structure.js
@@ -259,6 +259,6 @@ export const structure = [
       'Common form use cases from application configuration to payment acceptance.',
     icon: size => <IconBrand size={size} />,
     seoDescription: 'HPE Design System form examples and templates.',
-    sections: ['Sign In', 'Sign Up', 'Change Password'],
+    sections: ['Sign In', 'Sign Up', 'Change Password', 'Settings'],
   },
 ];

--- a/aries-site/src/examples/templates/forms/ChangePasswordExample.js
+++ b/aries-site/src/examples/templates/forms/ChangePasswordExample.js
@@ -6,7 +6,6 @@ import {
   FormField,
   Header,
   Heading,
-  Main,
   Text,
   TextInput,
 } from 'grommet';
@@ -44,7 +43,7 @@ export const ChangePasswordExample = () => {
             Change Password
           </Heading>
         </Header>
-        <Main
+        <Box
           // Padding used to prevent focus from being cutoff
           pad={{ horizontal: 'xxsmall' }}
         >
@@ -108,7 +107,7 @@ export const ChangePasswordExample = () => {
               />
             </Box>
           </Form>
-        </Main>
+        </Box>
       </Box>
     </FormContainer>
   );

--- a/aries-site/src/examples/templates/forms/SettingsExample.js
+++ b/aries-site/src/examples/templates/forms/SettingsExample.js
@@ -1,0 +1,105 @@
+import React from 'react';
+import {
+  Box,
+  Button,
+  CheckBox,
+  Form,
+  FormField,
+  Header,
+  Heading,
+  Main,
+  MaskedInput,
+  RangeInput,
+  Text,
+  TextInput,
+} from 'grommet';
+
+import { FormContainer } from '.';
+
+export const SettingsExample = () => {
+  const [formValues, setFormValues] = React.useState({
+    doNotDisturbHours: '9:00pm - 5:00am',
+    notifications: true,
+    notificationsVolume: 0.7,
+  });
+
+  // eslint-disable-next-line no-unused-vars
+  const onSubmit = ({ value, touched }) => {
+    // Your submission logic here
+  };
+
+  return (
+    <FormContainer width="medium">
+      <Box gap="medium">
+        <Header
+          direction="column"
+          align="start"
+          gap="xxsmall"
+          pad={{ horizontal: 'xxsmall' }}
+        >
+          <Heading level={3} margin="none">
+            Settings
+          </Heading>
+          <Text>for HPE Service</Text>
+        </Header>
+        <Main
+          // Padding used to prevent focus from being cutoff
+          pad={{ horizontal: 'xxsmall' }}
+        >
+          <Form
+            value={formValues}
+            onChange={setFormValues}
+            onSubmit={({ value, touched }) => onSubmit({ value, touched })}
+          >
+            <Box margin={{ bottom: 'small' }}>
+              <Text margin={{ left: 'small' }}>Key feature</Text>
+              <FormField
+                name="notifications"
+                label="Notifications"
+                component={CheckBox}
+                reverse
+                help="Description of feature"
+                toggle
+              />
+              <FormField
+                htmlFor="notificationsVolume"
+                name="notificationsVolume"
+                label="Notifications Volume"
+              >
+                <RangeInput
+                  id="notificationsVolume"
+                  name="notificationsVolume"
+                  max={1}
+                  min={0}
+                  pad
+                  step={0.1}
+                />
+              </FormField>
+            </Box>
+            <Box margin={{ bottom: 'small' }}>
+              <Text margin={{ left: 'small' }}>Key feature</Text>
+              <FormField
+                name="doNotDisturb"
+                label="Do Not Disturb"
+                component={CheckBox}
+                help="Description of feature"
+                reverse
+                toggle
+              />
+              <FormField htmlFor="doNotDisturbHours" name="doNotDisturbHours">
+                <TextInput
+                  id="doNotDisturbHours"
+                  name="doNotDisturbHours"
+                  disabled={!formValues.doNotDisturb}
+                />
+              </FormField>
+            </Box>
+            <Box align="start" margin={{ top: 'medium', bottom: 'small' }}>
+              <Button label="Apply Settings" primary type="submit" />
+            </Box>
+          </Form>
+        </Main>
+      </Box>
+    </FormContainer>
+  );
+};

--- a/aries-site/src/examples/templates/forms/SettingsExample.js
+++ b/aries-site/src/examples/templates/forms/SettingsExample.js
@@ -7,8 +7,6 @@ import {
   FormField,
   Header,
   Heading,
-  Main,
-  MaskedInput,
   RangeInput,
   Text,
   TextInput,
@@ -42,7 +40,7 @@ export const SettingsExample = () => {
           </Heading>
           <Text>for HPE Service</Text>
         </Header>
-        <Main
+        <Box
           // Padding used to prevent focus from being cutoff
           pad={{ horizontal: 'xxsmall' }}
         >
@@ -98,7 +96,7 @@ export const SettingsExample = () => {
               <Button label="Apply Settings" primary type="submit" />
             </Box>
           </Form>
-        </Main>
+        </Box>
       </Box>
     </FormContainer>
   );

--- a/aries-site/src/examples/templates/forms/SignInExample.js
+++ b/aries-site/src/examples/templates/forms/SignInExample.js
@@ -9,7 +9,6 @@ import {
   Header,
   Heading,
   Layer,
-  Main,
   Text,
   TextInput,
 } from 'grommet';
@@ -112,7 +111,7 @@ export const SignInExample = () => {
           </Heading>
           <Text>to Hewlett Packard Enterprise</Text>
         </Header>
-        <Main
+        <Box
           // Padding used to prevent focus from being cutoff
           pad={{ horizontal: 'xxsmall' }}
         >
@@ -179,7 +178,7 @@ export const SignInExample = () => {
               </Layer>
             )}
           </Box>
-        </Main>
+        </Box>
       </Box>
     </FormContainer>
   );

--- a/aries-site/src/examples/templates/forms/SignUpExample.js
+++ b/aries-site/src/examples/templates/forms/SignUpExample.js
@@ -8,7 +8,6 @@ import {
   FormField,
   Header,
   Heading,
-  Main,
   MaskedInput,
   Text,
   TextInput,
@@ -41,7 +40,7 @@ export const SignUpExample = () => {
           </Heading>
           <Text>for a Hewlett Packard Enterprise account</Text>
         </Header>
-        <Main
+        <Box
           // Padding used to prevent focus from being cutoff
           pad={{ horizontal: 'xxsmall' }}
         >
@@ -121,7 +120,7 @@ export const SignUpExample = () => {
               <Button label="Sign up" primary type="submit" />
             </Box>
           </Form>
-        </Main>
+        </Box>
       </Box>
     </FormContainer>
   );

--- a/aries-site/src/examples/templates/forms/index.js
+++ b/aries-site/src/examples/templates/forms/index.js
@@ -1,5 +1,6 @@
 export * from './ChangePasswordExample';
 export * from './FormContainer';
 export * from './formHelpers';
+export * from './SettingsExample';
 export * from './SignInExample';
 export * from './SignUpExample';

--- a/aries-site/src/pages/templates/forms.js
+++ b/aries-site/src/pages/templates/forms.js
@@ -3,6 +3,7 @@ import React from 'react';
 import { Meta, SubsectionText } from '../../components';
 import {
   ChangePasswordExample,
+  SettingsExample,
   SignInExample,
   SignUpExample,
 } from '../../examples';
@@ -57,6 +58,16 @@ const Forms = () => {
             figma="https://www.figma.com/file/K0PppsSh6aQSszqlwKAekg/hpe-design-system-stickers?node-id=259%3A85"
           >
             <ChangePasswordExample />
+          </Example>
+        </Subsection>
+      </ContentSection>
+      <ContentSection>
+        <Subsection name="Settings">
+          <Example
+            code="https://raw.githubusercontent.com/hpe-design/design-system/master/aries-site/src/examples/templates/forms/SettingsExample.js"
+            figma="https://www.figma.com/file/K0PppsSh6aQSszqlwKAekg/hpe-design-system-stickers?node-id=267%3A77"
+          >
+            <SettingsExample />
           </Example>
         </Subsection>
       </ContentSection>

--- a/aries-site/src/themes/aries.js
+++ b/aries-site/src/themes/aries.js
@@ -1,10 +1,55 @@
 import { hpe } from 'grommet-theme-hpe';
-import { deepMerge } from 'grommet/utils';
+import { deepMerge, normalizeColor } from 'grommet/utils';
 
 export const aries = deepMerge(hpe, {
   defaultMode: 'dark',
   layer: {
     background: 'background',
+  },
+  checkBox: {
+    toggle: {
+      color: {
+        dark: hpe.global.colors['text-strong'].dark,
+        light: hpe.global.colors['text-strong'].dark,
+      },
+      background: 'background-back',
+      extend: ({ checked, theme }) => `
+          border: none;
+          ${checked && `background-color: ${normalizeColor('brand', theme)};`}
+      `,
+      knob: {
+        extend: ({ theme }) => `
+          border: 2px solid ${theme.global.colors.text.light};
+          top: 0px;
+        `,
+      },
+    },
+  },
+  rangeInput: {
+    thumb: {
+      color: {
+        dark: 'text-strong',
+        light: hpe.global.colors['text-strong'].dark,
+      },
+      extend: ({ theme }) => `
+        border: 2px solid ${theme.global.colors.text.light};
+      `,
+    },
+    track: {
+      extend: ({ max, theme, value }) => {
+        const lowerTrack = normalizeColor('brand', theme);
+        const upperTrack = normalizeColor('background-contrast', theme);
+        const trackPoint = `${(value / max) * 100}%`;
+
+        return `background: linear-gradient(
+          to right, 
+          ${lowerTrack}, 
+          ${lowerTrack} ${trackPoint},
+          ${upperTrack} ${trackPoint},
+          ${upperTrack}
+        );`;
+      },
+    },
   },
 });
 


### PR DESCRIPTION
Related Issues: https://github.com/hpe-design/design-system/issues/464

[Preview](https://deploy-preview-465--keen-mayer-a86c8b.netlify.com/templates/forms#settings)

[Design](https://www.figma.com/file/K0PppsSh6aQSszqlwKAekg/hpe-design-system-stickers?node-id=267%3A77)

Work Included:
- Added `SettingsExample` to `Templates/Forms`
- Extended `aries` theme to support Toggle and RangeInput styling (changes here will eventually need to be ported over to `grommet-theme-hpe` and then pruned from `aries` theme)

![Screen Shot 2020-03-05 at 9 54 42 AM](https://user-images.githubusercontent.com/1756948/76004979-a0f2f000-5ec7-11ea-961f-e5c5a436633f.png)
