### PR TITLE
Update Footer Layout and anchor text size

### DIFF
--- a/aries-site/src/layouts/main/Footer.js
+++ b/aries-site/src/layouts/main/Footer.js
@@ -21,7 +21,7 @@ export const Footer = () => {
   ];
   return (
     <GrommetFooter
-      direction={size !== 'small' ? 'row' : 'column-reverse'}
+      direction="row-responsive"
       align={size !== 'small' ? 'center' : undefined}
       pad={{
         vertical: size !== 'small' ? 'small' : 'large',
@@ -34,9 +34,10 @@ export const Footer = () => {
           &copy; {year} Hewlett Packard Enterprise Development LP
         </Text>
       </Box>
-      <Box alignSelf="center" direction="row" gap="medium">
+      <Box direction="row" gap="medium">
         {externalFooterLinks.map((link, index) => (
           <FooterLink
+            size="small"
             key={index}
             href={link.href}
             label={link.label}
@@ -47,7 +48,7 @@ export const Footer = () => {
         {/* Need to pass href because of:
         https://github.com/zeit/next.js/#forcing-the-link-to-expose-href-to-its-child */}
         <Link href={nameToPath('Feedback')} passHref>
-          <FooterLink label="Feedback" />
+          <FooterLink size="small" label="Feedback" />
         </Link>
       </Box>
     </GrommetFooter>


### PR DESCRIPTION
Preview: TBD

Updating Footer responsive layout to match what is displayed in the latest designs: https://www.figma.com/file/9aoCaf5lqzdQv1q4NFi0GN/hpe-design-system-library-footer?node-id=2%3A39

Anchor size should be "small" so that text size matches the text on left size of footer (16px). Responsive layout now leaves the HPE Development LP on top with links below, and leaves everything left justified.