### PR TITLE
Update Home page title to "HPE Design System"

### DIFF
--- a/aries-site/src/components/seo/Meta.js
+++ b/aries-site/src/components/seo/Meta.js
@@ -27,7 +27,9 @@ export const Meta = ({ title, description, canonicalUrl, socialImageUrl }) => {
   return (
     <Head>
       <title>
-        {title ? `${title} — HPE Design System` : 'HPE Design System'}
+        {title && title !== 'Home'
+          ? `${title} — HPE Design System`
+          : 'HPE Design System'}
       </title>
       <meta
         key="viewport"

--- a/aries-site/src/layouts/content/Head.js
+++ b/aries-site/src/layouts/content/Head.js
@@ -5,7 +5,9 @@ import HeadNext from 'next/head';
 export const Head = ({ title }) => (
   <HeadNext>
     <title>
-      {title ? `${title} — HPE Design System` : 'HPE Design System'}
+      {title && title !== 'Home'
+        ? `${title} — HPE Design System`
+        : 'HPE Design System'}
     </title>
     <link rel="icon" href="/static/favicon.ico" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />


### PR DESCRIPTION
Updates Meta and Head so that the Home page doesn't have title "Home — HPE Design System"

Closes #468 