### PR TITLE
Update develop page to include starter info

### DIFF
--- a/aries-site/src/data/structure.js
+++ b/aries-site/src/data/structure.js
@@ -90,6 +90,12 @@ export const structure = [
     seoDescription:
       'HPE Design System coding best practices, concepts, and requirements when implementing user interfaces for digital experiences.',
     pages: [],
+    sections: [
+      'Preferred environment',
+      'Getting started',
+      'Applying the HPE theme',
+      "What is our team doesn't use ReactJS?",
+    ],
   },
   {
     name: 'Design',

--- a/aries-site/src/layouts/content/Subsection.js
+++ b/aries-site/src/layouts/content/Subsection.js
@@ -14,7 +14,14 @@ const GAP_SIZE = {
   3: undefined,
 };
 
-export const Subsection = ({ children, showHeading, level, name, topic }) => {
+export const Subsection = ({
+  children,
+  showHeading,
+  level,
+  name,
+  topic,
+  ...rest
+}) => {
   const [over, setOver] = useState(false);
 
   const id = name
@@ -51,6 +58,7 @@ export const Subsection = ({ children, showHeading, level, name, topic }) => {
       onMouseOut={() => setOver(false)}
       onFocus={() => setOver(true)}
       onBlur={() => setOver(false)}
+      {...rest}
     >
       {/* This condition for gap is needed because the link icon has padding
        * to maintain a big enough touch area for accessibility. This creates

--- a/aries-site/src/pages/design/index.js
+++ b/aries-site/src/pages/design/index.js
@@ -1,7 +1,7 @@
 import React from 'react';
 
-import { Layout, NavPage } from '../../layouts';
-import { ComingSoon, DescriptiveHeader, Meta } from '../../components';
+import { ContentSection, Layout, NavPage, Subsection } from '../../layouts';
+import { DescriptiveHeader, Meta, SubsectionText } from '../../components';
 import { getPageDetails } from '../../utils';
 
 const title = 'Design';
@@ -27,7 +27,58 @@ const Design = () => {
       {page.pages.length ? (
         <NavPage items={page.pages} topic={page.name.toLowerCase()} />
       ) : (
-        <ComingSoon />
+        <>
+          <ContentSection>
+            <Subsection name="Preferred">
+              <SubsectionText>
+                The HPE Design System is primarily focused on user interfaces
+                developed with ReactJS and Grommet. There are more resources,
+                examples, and community help for this environment.
+              </SubsectionText>
+              <SubsectionText size="medium">
+                The HPE Design System contains an open-source library of
+                elements consisting of working code, best practices, design
+                resources, human-centered guidelines, and a vibrant community of
+                contributors.
+              </SubsectionText>
+            </Subsection>
+          </ContentSection>
+          <ContentSection>
+            <Subsection name="Alternatives">
+              <SubsectionText>
+                The HPE Design System’s ethos is rooted and thrives in an
+                environment of generosity and community. It seeks to share and
+                invite conversations that are inclusive, as well as to boldly
+                express the cultural DNA of Hewlett Packard Enterprise.
+                Embracing the courage and commitment to learn, share and serve
+                with uncompromising integrity, the HPE Design System will
+                advance the way people live and work.
+              </SubsectionText>
+            </Subsection>
+            <Subsection name="Generous">
+              <SubsectionText>
+                Living generously requires understanding the needs of others.
+                The HPE Design System is crafted upon user research and
+                listening to customers first. We can then bring to bear the
+                experiences that generously provide for the needs of people and
+                their work. It requires a humility and position that is ready to
+                serve others and continues to relentless pursue excellence in
+                its craft for the sake of others.
+              </SubsectionText>
+            </Subsection>
+            <Subsection name="Community">
+              <SubsectionText>
+                Partnering in community allows the HPE Design System to be built
+                upon the energy and empowerment of collaboration. The community
+                provides accountability, conversation and relationships that are
+                the crucible for generating innovation. Community is the fuel
+                for the fires of creativity and allows the Design System to
+                expand and thrive. Best of all, it’s a great place to find
+                support and celebrate success!
+              </SubsectionText>
+            </Subsection>
+          </ContentSection>
+        </>
       )}
     </Layout>
   );

--- a/aries-site/src/pages/design/index.js
+++ b/aries-site/src/pages/design/index.js
@@ -1,7 +1,7 @@
 import React from 'react';
 
-import { ContentSection, Layout, NavPage, Subsection } from '../../layouts';
-import { DescriptiveHeader, Meta, SubsectionText } from '../../components';
+import { Layout, NavPage } from '../../layouts';
+import { ComingSoon, DescriptiveHeader, Meta } from '../../components';
 import { getPageDetails } from '../../utils';
 
 const title = 'Design';
@@ -27,58 +27,7 @@ const Design = () => {
       {page.pages.length ? (
         <NavPage items={page.pages} topic={page.name.toLowerCase()} />
       ) : (
-        <>
-          <ContentSection>
-            <Subsection name="Preferred">
-              <SubsectionText>
-                The HPE Design System is primarily focused on user interfaces
-                developed with ReactJS and Grommet. There are more resources,
-                examples, and community help for this environment.
-              </SubsectionText>
-              <SubsectionText size="medium">
-                The HPE Design System contains an open-source library of
-                elements consisting of working code, best practices, design
-                resources, human-centered guidelines, and a vibrant community of
-                contributors.
-              </SubsectionText>
-            </Subsection>
-          </ContentSection>
-          <ContentSection>
-            <Subsection name="Alternatives">
-              <SubsectionText>
-                The HPE Design System’s ethos is rooted and thrives in an
-                environment of generosity and community. It seeks to share and
-                invite conversations that are inclusive, as well as to boldly
-                express the cultural DNA of Hewlett Packard Enterprise.
-                Embracing the courage and commitment to learn, share and serve
-                with uncompromising integrity, the HPE Design System will
-                advance the way people live and work.
-              </SubsectionText>
-            </Subsection>
-            <Subsection name="Generous">
-              <SubsectionText>
-                Living generously requires understanding the needs of others.
-                The HPE Design System is crafted upon user research and
-                listening to customers first. We can then bring to bear the
-                experiences that generously provide for the needs of people and
-                their work. It requires a humility and position that is ready to
-                serve others and continues to relentless pursue excellence in
-                its craft for the sake of others.
-              </SubsectionText>
-            </Subsection>
-            <Subsection name="Community">
-              <SubsectionText>
-                Partnering in community allows the HPE Design System to be built
-                upon the energy and empowerment of collaboration. The community
-                provides accountability, conversation and relationships that are
-                the crucible for generating innovation. Community is the fuel
-                for the fires of creativity and allows the Design System to
-                expand and thrive. Best of all, it’s a great place to find
-                support and celebrate success!
-              </SubsectionText>
-            </Subsection>
-          </ContentSection>
-        </>
+        <ComingSoon />
       )}
     </Layout>
   );

--- a/aries-site/src/pages/develop/index.js
+++ b/aries-site/src/pages/develop/index.js
@@ -1,7 +1,8 @@
 import React from 'react';
+import { Anchor } from 'grommet';
 
-import { Layout, NavPage } from '../../layouts';
-import { ComingSoon, DescriptiveHeader, Meta } from '../../components';
+import { ContentSection, Layout, NavPage, Subsection } from '../../layouts';
+import { DescriptiveHeader, Meta, SubsectionText } from '../../components';
 import { getPageDetails } from '../../utils';
 
 const title = 'Develop';
@@ -27,7 +28,65 @@ const Develop = () => {
       {page.pages.length ? (
         <NavPage items={page.pages} topic={page.name.toLowerCase()} />
       ) : (
-        <ComingSoon />
+        <>
+          <ContentSection>
+            <Subsection name="Preferred">
+              <SubsectionText>
+                The HPE Design System is primarily focused on user interfaces
+                developed with ReactJS and Grommet. There are more resources,
+                examples, and community help for this environment.
+              </SubsectionText>
+              <SubsectionText size="medium">
+                If you are new to ReactJS, the{' '}
+                <Anchor
+                  label="React Tutorial"
+                  href="https://reactjs.org/tutorial/tutorial.html"
+                />{' '}
+                is a good place to start.
+              </SubsectionText>
+              <SubsectionText size="medium">
+                If you are already familiar with ReactJS but are unfamiliar with
+                Grommet, check out the{' '}
+                <Anchor
+                  label="Getting Started with Grommet"
+                  href="https://v2.grommet.io/starter"
+                />{' '}
+                guide.
+              </SubsectionText>
+              <SubsectionText size="medium">
+                If you are already familiar with ReactJS and Grommet, make sure
+                you have the latest <code>grommet-theme-hpe</code> theme
+                via <code>npm</code> or <code>yarn</code>.
+              </SubsectionText>
+              <SubsectionText size="medium">
+                Questions and feedback should be routed through the
+                #hpe-design-system channel on{' '}
+                <Anchor label="Slack" href="https://grommet.slack.com" />.
+              </SubsectionText>
+            </Subsection>
+          </ContentSection>
+          <ContentSection>
+            <Subsection name="Alternatives">
+              <SubsectionText>
+                For non-ReactJS environments, such as those with a large code
+                base that are not ready to absorb changing the UI framework, we
+                recommend using the examples and patterns shown in the HPE
+                Design System as a reference to update their style to get close.
+                This could be done by inspecting the styling in the browser
+                developer tools.
+              </SubsectionText>
+              <SubsectionText>
+                If you have questions or would like some guidance in migrating
+                to ReactJS, please reach out to the{' '}
+                <Anchor
+                  label="HPE Design System team"
+                  href="mailto:designsystem-req@hpe.com"
+                />
+                .
+              </SubsectionText>
+            </Subsection>
+          </ContentSection>
+        </>
       )}
     </Layout>
   );

--- a/aries-site/src/pages/develop/index.js
+++ b/aries-site/src/pages/develop/index.js
@@ -1,7 +1,11 @@
 import React from 'react';
 import { Anchor } from 'grommet';
-
-import { ContentSection, Layout, NavPage, Subsection } from '../../layouts';
+import {
+  ContentSection,
+  FeedbackSection,
+  Layout,
+  Subsection,
+} from '../../layouts';
 import { DescriptiveHeader, Meta, SubsectionText } from '../../components';
 import { getPageDetails } from '../../utils';
 
@@ -17,7 +21,6 @@ const Develop = () => {
       title={title}
     />
   );
-
   return (
     <Layout descriptiveHeader={descriptiveHeader} title={title} isNavPage>
       <Meta
@@ -25,69 +28,88 @@ const Develop = () => {
         description={page.seoDescription}
         canonicalUrl="https://design-system.hpe.design/develop"
       />
-      {page.pages.length ? (
-        <NavPage items={page.pages} topic={page.name.toLowerCase()} />
-      ) : (
-        <>
-          <ContentSection>
-            <Subsection name="Preferred">
-              <SubsectionText>
-                The HPE Design System is primarily focused on user interfaces
-                developed with ReactJS and Grommet. There are more resources,
-                examples, and community help for this environment.
-              </SubsectionText>
-              <SubsectionText size="medium">
-                If you are new to ReactJS, the{' '}
-                <Anchor
-                  label="React Tutorial"
-                  href="https://reactjs.org/tutorial/tutorial.html"
-                />{' '}
-                is a good place to start.
-              </SubsectionText>
-              <SubsectionText size="medium">
-                If you are already familiar with ReactJS but are unfamiliar with
-                Grommet, check out the{' '}
-                <Anchor
-                  label="Getting Started with Grommet"
-                  href="https://v2.grommet.io/starter"
-                />{' '}
-                guide.
-              </SubsectionText>
-              <SubsectionText size="medium">
-                If you are already familiar with ReactJS and Grommet, make sure
-                you have the latest <code>grommet-theme-hpe</code> theme
-                via <code>npm</code> or <code>yarn</code>.
-              </SubsectionText>
-              <SubsectionText size="medium">
-                Questions and feedback should be routed through the
-                #hpe-design-system channel on{' '}
-                <Anchor label="Slack" href="https://grommet.slack.com" />.
-              </SubsectionText>
-            </Subsection>
-          </ContentSection>
-          <ContentSection>
-            <Subsection name="Alternatives">
-              <SubsectionText>
-                For non-ReactJS environments, such as those with a large code
-                base that are not ready to absorb changing the UI framework, we
-                recommend using the examples and patterns shown in the HPE
-                Design System as a reference to update their style to get close.
-                This could be done by inspecting the styling in the browser
-                developer tools.
-              </SubsectionText>
-              <SubsectionText>
-                If you have questions or would like some guidance in migrating
-                to ReactJS, please reach out to the{' '}
-                <Anchor
-                  label="HPE Design System team"
-                  href="mailto:designsystem-req@hpe.com"
-                />
-                .
-              </SubsectionText>
-            </Subsection>
-          </ContentSection>
-        </>
-      )}
+      <ContentSection>
+        <Subsection name="Preferred environment" pad={{ top: 'medium' }}>
+          <SubsectionText>
+            The HPE Design System is primarily focused on user interfaces
+            developed with ReactJS and Grommet. We encourage teams to use
+            ReactJS and Grommet if possible because there are more resources,
+            examples, and community help for this environment.
+          </SubsectionText>
+          <SubsectionText>
+            Questions and feedback should be routed through the
+            #hpe-design-system channel on{' '}
+            <Anchor
+              label="Slack"
+              href="https://grommet.slack.com"
+              target="_blank"
+              rel="noopener noreferrer"
+            />
+            .
+          </SubsectionText>
+        </Subsection>
+        <Subsection name="Getting started">
+          <SubsectionText>
+            If you are new to ReactJS, the{' '}
+            <Anchor
+              label="React Tutorial"
+              href="https://reactjs.org/tutorial/tutorial.html"
+              target="_blank"
+              rel="noopener noreferrer"
+            />{' '}
+            is a good place to start.
+          </SubsectionText>
+          <SubsectionText size="medium">
+            If you are already familiar with ReactJS but are unfamiliar with
+            Grommet, check out the{' '}
+            <Anchor
+              label="Getting Started with Grommet"
+              href="https://v2.grommet.io/starter"
+              target="_blank"
+              rel="noopener noreferrer"
+            />{' '}
+            guide.
+          </SubsectionText>
+        </Subsection>
+        <Subsection name="Applying the HPE theme">
+          <SubsectionText>
+            Once your project is set up with ReactJS and Grommet, make sure you
+            have the latest{' '}
+            <Anchor
+              href="https://github.com/grommet/grommet-theme-hpe"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              <code>grommet-theme-hpe</code>
+            </Anchor>{' '}
+            theme via <code>npm</code> or <code>yarn</code>. This will help
+            ensure that your application is aligned with the HPE Design System
+            colors, fonts, and default component styles.
+          </SubsectionText>
+        </Subsection>
+      </ContentSection>
+      <ContentSection>
+        <Subsection name="What if our team doesn't use ReactJS?">
+          <SubsectionText>
+            For non-ReactJS environments, such as those with a large code base
+            that are not ready to absorb changing the UI framework, we recommend
+            using the examples and patterns shown in the HPE Design System as a
+            reference. Styles should be matched as closely as possible. Using
+            the browser develop tools to inspect the styling can help with this
+            process.
+          </SubsectionText>
+          <SubsectionText>
+            If you have questions or would like some guidance on migrating to
+            ReactJS, please reach out to the{' '}
+            <Anchor
+              label="HPE Design System team"
+              href="mailto:hpedesignsystem@hpe.com"
+            />
+            .
+          </SubsectionText>
+        </Subsection>
+      </ContentSection>
+      <FeedbackSection />
     </Layout>
   );
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -2624,11 +2624,6 @@ abab@^2.0.0:
   resolved "https://registry.yarnpkg.com/abab/-/abab-2.0.3.tgz#623e2075e02eb2d3f2475e49f99c91846467907a"
   integrity sha512-tsFzPpcttalNjFBCFMqsKYQcWxxen1pgJR56by//QwvJc4/OUS3kPOOttx2tSIfjsylB0pYu7f5D3K1RCxUnUg==
 
-abbrev@1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/abbrev/-/abbrev-1.1.1.tgz#f8f2c887ad10bf67f634f005b6987fed3179aac8"
-  integrity sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==
-
 accepts@~1.3.4, accepts@~1.3.5, accepts@~1.3.7:
   version "1.3.7"
   resolved "https://registry.yarnpkg.com/accepts/-/accepts-1.3.7.tgz#531bc726517a3b2b41f850021c6cc15eaab507cd"
@@ -5734,7 +5729,7 @@ debug@=3.1.0:
   dependencies:
     ms "2.0.0"
 
-debug@^3.0.0, debug@^3.0.1, debug@^3.1.0, debug@^3.1.1, debug@^3.2.5, debug@^3.2.6:
+debug@^3.0.0, debug@^3.0.1, debug@^3.1.0, debug@^3.1.1, debug@^3.2.5:
   version "3.2.6"
   resolved "https://registry.yarnpkg.com/debug/-/debug-3.2.6.tgz#e83d17de16d8a7efb7717edbe5fb10135eee629b"
   integrity sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==
@@ -5784,11 +5779,6 @@ deep-equal@^1.0.1, deep-equal@^1.1.1:
     object-is "^1.0.1"
     object-keys "^1.1.1"
     regexp.prototype.flags "^1.2.0"
-
-deep-extend@^0.6.0:
-  version "0.6.0"
-  resolved "https://registry.yarnpkg.com/deep-extend/-/deep-extend-0.6.0.tgz#c4fa7c95404a17a9c3e8ca7e1537312b736330ac"
-  integrity sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==
 
 deep-is@~0.1.3:
   version "0.1.3"
@@ -5939,11 +5929,6 @@ detect-indent@^4.0.0:
   integrity sha1-920GQ1LN9Docts5hnE7jqUdd4gg=
   dependencies:
     repeating "^2.0.0"
-
-detect-libc@^1.0.2:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/detect-libc/-/detect-libc-1.0.3.tgz#fa137c4bd698edf55cd5cd02ac559f91a4c4ba9b"
-  integrity sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=
 
 detect-newline@^3.0.0:
   version "3.1.0"
@@ -7399,13 +7384,6 @@ fs-extra@^8.0.1, fs-extra@^8.1.0:
     jsonfile "^4.0.0"
     universalify "^0.1.0"
 
-fs-minipass@^1.2.5:
-  version "1.2.7"
-  resolved "https://registry.yarnpkg.com/fs-minipass/-/fs-minipass-1.2.7.tgz#ccff8570841e7fe4265693da88936c55aed7f7c7"
-  integrity sha512-GWSSJGFy4e9GUeCcbIkED+bgAoFyj7XF1mV8rma3QW4NIqX9Kyx79N/PF61H5udOV3aY1IaMLs6pGbH71nlCTA==
-  dependencies:
-    minipass "^2.6.0"
-
 fs-minipass@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/fs-minipass/-/fs-minipass-2.1.0.tgz#7f5036fdbf12c63c169190cbe4199c852271f9fb"
@@ -7761,7 +7739,6 @@ grommet-theme-hpe@^1.0.2:
 
 "grommet@https://github.com/grommet/grommet/tarball/stable":
   version "2.11.1"
-  uid "65fe8dddf7c701c9f72337b9d1520914d054bae6"
   resolved "https://github.com/grommet/grommet/tarball/stable#65fe8dddf7c701c9f72337b9d1520914d054bae6"
   dependencies:
     css "^2.2.3"
@@ -8156,7 +8133,7 @@ iconv-lite@0.4.11:
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.11.tgz#2ecb42fd294744922209a2e7c404dac8793d8ade"
   integrity sha1-LstC/SlHRJIiCaLnxATayHk9it4=
 
-iconv-lite@0.4.24, iconv-lite@^0.4.24, iconv-lite@^0.4.4, iconv-lite@~0.4.13:
+iconv-lite@0.4.24, iconv-lite@^0.4.24, iconv-lite@~0.4.13:
   version "0.4.24"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.24.tgz#2022b4b25fbddc21d2f524974a474aafe733908b"
   integrity sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==
@@ -8184,13 +8161,6 @@ ignore-loader@0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/ignore-loader/-/ignore-loader-0.1.2.tgz#d81f240376d0ba4f0d778972c3ad25874117a463"
   integrity sha1-2B8kA3bQuk8Nd4lyw60lh0EXpGM=
-
-ignore-walk@^3.0.1:
-  version "3.0.3"
-  resolved "https://registry.yarnpkg.com/ignore-walk/-/ignore-walk-3.0.3.tgz#017e2447184bfeade7c238e4aefdd1e8f95b1e37"
-  integrity sha512-m7o6xuOaT1aqheYHKf8W6J5pYH85ZI9w077erOzLje3JsB1gkafkAhHHY19dqjulgIZHFm32Cp5uNZgcQqdJKw==
-  dependencies:
-    minimatch "^3.0.4"
 
 ignore@^3.3.5:
   version "3.3.10"
@@ -8315,7 +8285,7 @@ inherits@2.0.3:
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.3.tgz#633c2c83e3da42a502f52466022480f4208261de"
   integrity sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=
 
-ini@^1.3.4, ini@^1.3.5, ini@~1.3.0:
+ini@^1.3.4, ini@^1.3.5:
   version "1.3.5"
   resolved "https://registry.yarnpkg.com/ini/-/ini-1.3.5.tgz#eee25f56db1c9ec6085e0c22778083f596abf927"
   integrity sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==
@@ -10238,27 +10208,12 @@ minipass-pipeline@^1.2.2:
   dependencies:
     minipass "^3.0.0"
 
-minipass@^2.6.0, minipass@^2.8.6, minipass@^2.9.0:
-  version "2.9.0"
-  resolved "https://registry.yarnpkg.com/minipass/-/minipass-2.9.0.tgz#e713762e7d3e32fed803115cf93e04bca9fcc9a6"
-  integrity sha512-wxfUjg9WebH+CUDX/CdbRlh5SmfZiy/hpkxaRI16Y9W56Pa75sWgd/rvFilSgrauD9NyFymP/+JFV3KwzIsJeg==
-  dependencies:
-    safe-buffer "^5.1.2"
-    yallist "^3.0.0"
-
 minipass@^3.0.0, minipass@^3.1.1:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/minipass/-/minipass-3.1.1.tgz#7607ce778472a185ad6d89082aa2070f79cedcd5"
   integrity sha512-UFqVihv6PQgwj8/yTGvl9kPz7xIAY+R5z6XYjRInD3Gk3qx6QGSD6zEcpeG4Dy/lQnv1J6zv8ejV90hyYIKf3w==
   dependencies:
     yallist "^4.0.0"
-
-minizlib@^1.2.1:
-  version "1.3.3"
-  resolved "https://registry.yarnpkg.com/minizlib/-/minizlib-1.3.3.tgz#2290de96818a34c29551c8a8d301216bd65a861d"
-  integrity sha512-6ZYMOEnmVsdCeTJVE0W9ZD+pVnE8h9Hma/iOwwRDsdQoePpoX56/8B6z3P9VNwppJuBKNRuFDRNRqRWexT9G9Q==
-  dependencies:
-    minipass "^2.9.0"
 
 mississippi@^3.0.0:
   version "3.0.0"
@@ -10292,7 +10247,7 @@ mixin-object@^2.0.1:
     for-in "^0.1.3"
     is-extendable "^0.1.1"
 
-mkdirp@0.5.1, mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@~0.5.1:
+mkdirp@0.5.1, mkdirp@^0.5.1, mkdirp@~0.5.1:
   version "0.5.1"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.1.tgz#30057438eac6cf7f8c4767f38648d6697d75c903"
   integrity sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=
@@ -10405,15 +10360,6 @@ natural-compare@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
   integrity sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=
-
-needle@^2.2.1:
-  version "2.3.2"
-  resolved "https://registry.yarnpkg.com/needle/-/needle-2.3.2.tgz#3342dea100b7160960a450dc8c22160ac712a528"
-  integrity sha512-DUzITvPVDUy6vczKKYTnWc/pBZ0EnjMJnQ3y+Jo5zfKFimJs7S3HFCxCRZYB9FUZcrzUQr3WsmvZgddMEIZv6w==
-  dependencies:
-    debug "^3.2.6"
-    iconv-lite "^0.4.4"
-    sax "^1.2.4"
 
 negotiator@0.6.2:
   version "0.6.2"
@@ -10650,22 +10596,6 @@ node-notifier@^6.0.0:
     shellwords "^0.1.1"
     which "^1.3.1"
 
-node-pre-gyp@*:
-  version "0.14.0"
-  resolved "https://registry.yarnpkg.com/node-pre-gyp/-/node-pre-gyp-0.14.0.tgz#9a0596533b877289bcad4e143982ca3d904ddc83"
-  integrity sha512-+CvDC7ZttU/sSt9rFjix/P05iS43qHCOOGzcr3Ry99bXG7VX953+vFyEuph/tfqoYu8dttBkE86JSKBO2OzcxA==
-  dependencies:
-    detect-libc "^1.0.2"
-    mkdirp "^0.5.1"
-    needle "^2.2.1"
-    nopt "^4.0.1"
-    npm-packlist "^1.1.6"
-    npmlog "^4.0.2"
-    rc "^1.2.7"
-    rimraf "^2.6.1"
-    semver "^5.3.0"
-    tar "^4.4.2"
-
 node-releases@^1.1.29, node-releases@^1.1.44, node-releases@^1.1.50:
   version "1.1.50"
   resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-1.1.50.tgz#803c40d2c45db172d0410e4efec83aa8c6ad0592"
@@ -10677,14 +10607,6 @@ node-version@^1.0.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/node-version/-/node-version-1.2.0.tgz#34fde3ffa8e1149bd323983479dda620e1b5060d"
   integrity sha512-ma6oU4Sk0qOoKEAymVoTvk8EdXEobdS7m/mAGhDJ8Rouugho48crHBORAmy5BoOcv8wraPM6xumapQp5hl4iIQ==
-
-nopt@^4.0.1:
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/nopt/-/nopt-4.0.1.tgz#d0d4685afd5415193c8c7505602d0d17cd64474d"
-  integrity sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=
-  dependencies:
-    abbrev "1"
-    osenv "^0.1.4"
 
 normalize-html-whitespace@1.0.0:
   version "1.0.0"
@@ -10728,27 +10650,6 @@ normalize-url@1.9.1:
     query-string "^4.1.0"
     sort-keys "^1.0.0"
 
-npm-bundled@^1.0.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/npm-bundled/-/npm-bundled-1.1.1.tgz#1edd570865a94cdb1bc8220775e29466c9fb234b"
-  integrity sha512-gqkfgGePhTpAEgUsGEgcq1rqPXA+tv/aVBlgEzfXwA1yiUJF7xtEt3CtVwOjNYQOVknDk0F20w58Fnm3EtG0fA==
-  dependencies:
-    npm-normalize-package-bin "^1.0.1"
-
-npm-normalize-package-bin@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/npm-normalize-package-bin/-/npm-normalize-package-bin-1.0.1.tgz#6e79a41f23fd235c0623218228da7d9c23b8f6e2"
-  integrity sha512-EPfafl6JL5/rU+ot6P3gRSCpPDW5VmIzX959Ob1+ySFUuuYHWHekXpwdUZcKP5C+DS4GEtdJluwBjnsNDl+fSA==
-
-npm-packlist@^1.1.6:
-  version "1.4.8"
-  resolved "https://registry.yarnpkg.com/npm-packlist/-/npm-packlist-1.4.8.tgz#56ee6cc135b9f98ad3d51c1c95da22bbb9b2ef3e"
-  integrity sha512-5+AZgwru5IevF5ZdnFglB5wNlHG1AOOuw28WhUq8/8emhBmLv6jX5by4WJCh7lW0uSYZYS6DXqIsyZVIXRZU9A==
-  dependencies:
-    ignore-walk "^3.0.1"
-    npm-bundled "^1.0.1"
-    npm-normalize-package-bin "^1.0.1"
-
 npm-run-path@^2.0.0:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/npm-run-path/-/npm-run-path-2.0.2.tgz#35a9232dfa35d7067b4cb2ddf2357b1871536c5f"
@@ -10763,7 +10664,7 @@ npm-run-path@^4.0.0:
   dependencies:
     path-key "^3.0.0"
 
-npmlog@^4.0.2, npmlog@^4.1.2:
+npmlog@^4.1.2:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/npmlog/-/npmlog-4.1.2.tgz#08a7f2a8bf734604779a9efa4ad5cc717abb954b"
   integrity sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==
@@ -11033,18 +10934,10 @@ os-locale@^3.0.0, os-locale@^3.1.0:
     lcid "^2.0.0"
     mem "^4.0.0"
 
-os-tmpdir@^1.0.0, os-tmpdir@^1.0.1, os-tmpdir@~1.0.1, os-tmpdir@~1.0.2:
+os-tmpdir@^1.0.1, os-tmpdir@~1.0.1, os-tmpdir@~1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/os-tmpdir/-/os-tmpdir-1.0.2.tgz#bbe67406c79aa85c5cfec766fe5734555dfa1274"
   integrity sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=
-
-osenv@^0.1.4:
-  version "0.1.5"
-  resolved "https://registry.yarnpkg.com/osenv/-/osenv-0.1.5.tgz#85cdfafaeb28e8677f416e287592b5f3f49ea410"
-  integrity sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==
-  dependencies:
-    os-homedir "^1.0.0"
-    os-tmpdir "^1.0.0"
 
 p-defer@^1.0.0:
   version "1.0.0"
@@ -12306,16 +12199,6 @@ raw-loader@^3.1.0:
     loader-utils "^1.1.0"
     schema-utils "^2.0.1"
 
-rc@^1.2.7:
-  version "1.2.8"
-  resolved "https://registry.yarnpkg.com/rc/-/rc-1.2.8.tgz#cd924bf5200a075b83c188cd6b9e211b7fc0d3ed"
-  integrity sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==
-  dependencies:
-    deep-extend "^0.6.0"
-    ini "~1.3.0"
-    minimist "^1.2.0"
-    strip-json-comments "~2.0.1"
-
 react-clientside-effect@^1.2.2:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/react-clientside-effect/-/react-clientside-effect-1.2.2.tgz#6212fb0e07b204e714581dd51992603d1accc837"
@@ -13040,7 +12923,7 @@ rimraf@2.6.3:
   dependencies:
     glob "^7.1.3"
 
-rimraf@^2.2.8, rimraf@^2.5.4, rimraf@^2.6.1, rimraf@^2.6.3, rimraf@^2.7.1:
+rimraf@^2.2.8, rimraf@^2.5.4, rimraf@^2.6.3, rimraf@^2.7.1:
   version "2.7.1"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.7.1.tgz#35797f13a7fdadc566142c29d4f07ccad483e3ec"
   integrity sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==
@@ -14011,7 +13894,7 @@ strip-indent@^3.0.0:
   dependencies:
     min-indent "^1.0.0"
 
-strip-json-comments@^2.0.1, strip-json-comments@~2.0.1:
+strip-json-comments@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-2.0.1.tgz#3c531942e908c2697c0ec344858c286c7ca0a60a"
   integrity sha1-PFMZQukIwml8DsNEhYwobHygpgo=
@@ -14162,19 +14045,6 @@ tapable@^1.0.0, tapable@^1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/tapable/-/tapable-1.1.3.tgz#a1fccc06b58db61fd7a45da2da44f5f3a3e67ba2"
   integrity sha512-4WK/bYZmj8xLr+HUCODHGF1ZFzsYffasLUgEiMBY4fgtltdO6B4WJtlSbPaDTLpYTcGVwM2qLnFTICEcNxs3kA==
-
-tar@^4.4.2:
-  version "4.4.13"
-  resolved "https://registry.yarnpkg.com/tar/-/tar-4.4.13.tgz#43b364bc52888d555298637b10d60790254ab525"
-  integrity sha512-w2VwSrBoHa5BsSyH+KxEqeQBAllHhccyMFVHtGtdMpF4W7IRWfZjFiQceJPChOeTsSDVUpER2T8FA93pr0L+QA==
-  dependencies:
-    chownr "^1.1.1"
-    fs-minipass "^1.2.5"
-    minipass "^2.8.6"
-    minizlib "^1.2.1"
-    mkdirp "^0.5.0"
-    safe-buffer "^5.1.2"
-    yallist "^3.0.3"
 
 telejson@^3.2.0:
   version "3.3.0"
@@ -15561,7 +15431,7 @@ y18n@^3.2.1:
   resolved "https://registry.yarnpkg.com/y18n/-/y18n-4.0.0.tgz#95ef94f85ecc81d007c264e190a120f0a3c8566b"
   integrity sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==
 
-yallist@^3.0.0, yallist@^3.0.2, yallist@^3.0.3:
+yallist@^3.0.2:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-3.1.1.tgz#dbb7daf9bfd8bac9ab45ebf602b8cbad0d5d08fd"
   integrity sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==


### PR DESCRIPTION
Preview: https://deploy-preview-488--keen-mayer-a86c8b.netlify.com/develop

This uses Eric's PR as a starter for content/layout of Develop page. I've separated the content into a few sections and linked to the grommet-hpe-theme. I think there could be more information that lives here potentially, but for now I've left it primarily with the content proposed by Eric's initial PR.

Closes #463 