### PR TITLE
First pass of Design page

### DIFF
--- a/aries-site/src/data/structure.js
+++ b/aries-site/src/data/structure.js
@@ -100,6 +100,11 @@ export const structure = [
     seoDescription:
       'View patterns, interactions, and other best practices for how to succeed using resources included with the HPE Design System.',
     pages: [],
+    sections: [
+      'Preferred environment',
+      'Getting started',
+      'HPE Design System Sticker Sheet',
+    ],
   },
   {
     name: 'Resources',

--- a/aries-site/src/pages/design/index.js
+++ b/aries-site/src/pages/design/index.js
@@ -1,7 +1,12 @@
 import React from 'react';
-
-import { Layout, NavPage } from '../../layouts';
-import { ComingSoon, DescriptiveHeader, Meta } from '../../components';
+import { Anchor } from 'grommet';
+import {
+  ContentSection,
+  FeedbackSection,
+  Layout,
+  Subsection,
+} from '../../layouts';
+import { DescriptiveHeader, Meta, SubsectionText } from '../../components';
 import { getPageDetails } from '../../utils';
 
 const title = 'Design';
@@ -24,11 +29,58 @@ const Design = () => {
         description={page.seoDescription}
         canonicalUrl="https://design-system.hpe.design/design"
       />
-      {page.pages.length ? (
-        <NavPage items={page.pages} topic={page.name.toLowerCase()} />
-      ) : (
-        <ComingSoon />
-      )}
+      <ContentSection>
+        <Subsection name="Preferred environment" pad={{ top: 'medium' }}>
+          <SubsectionText>
+            The HPE Design System library is maintained on Figma. Because Figma
+            is web-based, files can be easily shared across individuals and
+            teams, and teams can be confident they're always viewing the most
+            up-to-date versions of designs.
+          </SubsectionText>
+        </Subsection>
+        <Subsection name="Getting started" pad={{ top: 'medium' }}>
+          <SubsectionText>
+            If you are new to Figma, the{' '}
+            <Anchor
+              label="Figma Getting Started"
+              href="https://help.figma.com/hc/en-us/categories/360002051613-Getting-Started"
+              target="_blank"
+              rel="noopener noreferrer"
+            />{' '}
+            page is a good place to start.
+          </SubsectionText>
+          <SubsectionText>
+            Once you have made a Figma account with your HPE email, you can
+            request to join the HPE Design System team.
+          </SubsectionText>
+          <SubsectionText>
+            If you would prefer to access the HPE Design System library in a
+            desktop app, you can download the{' '}
+            <Anchor
+              label="Figma Desktop App"
+              href="https://help.figma.com/hc/en-us/articles/360039823654-Download-the-Figma-Desktop-App#Download_the_Desktop_App"
+              target="_blank"
+              rel="noopener noreferrer"
+            />{' '}
+            for MacOS or Windows.
+          </SubsectionText>
+        </Subsection>
+        <Subsection name="HPE Design System Sticker Sheet">
+          <SubsectionText>
+            The{' '}
+            <Anchor
+              label="HPE Design System sticker sheet"
+              href="https://www.figma.com/file/K0PppsSh6aQSszqlwKAekg/hpe-design-system-stickers"
+              target="_blank"
+              rel="noopener noreferrer"
+            />{' '}
+            provides a foundation for designing HPE applications. The sticker
+            sheet provides examples for default styles of components as well as
+            examples of styling aspects such as hover, focus, and active states.
+          </SubsectionText>
+        </Subsection>
+      </ContentSection>
+      <FeedbackSection />
     </Layout>
   );
 };

--- a/aries-site/src/tests/accessibility/axe.js
+++ b/aries-site/src/tests/accessibility/axe.js
@@ -77,8 +77,8 @@ test.before(async t => {
 });
 
 test.before(async t => {
-  await t.navigateTo('/design');
-})('should check Design Page (Empty Page)', async t => {
+  await t.navigateTo('/resources');
+})('should check Resources Page (Empty Page)', async t => {
   // Only need to run in one browser
   if (t.browser.name === 'Chrome') {
     const axeContext = {


### PR DESCRIPTION
Preview: https://deploy-preview-491--keen-mayer-a86c8b.netlify.com/design

First pass at design page. Includes link directly to sticker sheet and includes page sections in search.

One thing to note is that the headings of `Getting started` and `Preferred environment` exist on the Develop page as well, so in the search suggestions, the user wouldn't visually be able to distinguish what page each would link to. To fix this, we'd either need to update how search suggestions are displayed or change the headings on either the design or develop page to be unique.

Closes #490 