### PR TITLE
Fixing orphaned select form field label

### DIFF
--- a/aries-site/src/examples/templates/forms/FilterExample.js
+++ b/aries-site/src/examples/templates/forms/FilterExample.js
@@ -6,7 +6,6 @@ import {
   FormField,
   Header,
   Heading,
-  Main,
   Select,
   Text,
   TextInput,

--- a/aries-site/src/examples/templates/forms/FilterExample.js
+++ b/aries-site/src/examples/templates/forms/FilterExample.js
@@ -77,7 +77,7 @@ export const FilterExample = () => {
               />
             </FormField>
             <FormField
-              htmlFor="locationType"
+              htmlFor="locationType__input"
               name="locationType"
               label="Location Type"
             >


### PR DESCRIPTION
Resolves WAVE accessibility warning where select in a form field is reported as an orphaned label

**Before**
![Screen Shot 2020-03-11 at 10 39 49 AM](https://user-images.githubusercontent.com/1756948/76441199-a8614000-6384-11ea-86d6-4e3a2a3b4015.png)

**After** 
![Screen Shot 2020-03-11 at 10 39 28 AM](https://user-images.githubusercontent.com/1756948/76441207-aac39a00-6384-11ea-85a3-346438dd324f.png)
