### PR TITLE
Update form label, help, info, error, and placeholder styles

### DIFF
--- a/aries-site/src/examples/templates/forms/ChangePasswordExample.js
+++ b/aries-site/src/examples/templates/forms/ChangePasswordExample.js
@@ -6,7 +6,6 @@ import {
   FormField,
   Header,
   Heading,
-  Text,
   TextInput,
 } from 'grommet';
 
@@ -69,13 +68,9 @@ export const ChangePasswordExample = () => {
               htmlFor="newPassword"
               name="newPassword"
               label="New Password"
-              help={
-                <Text size="xsmall">
-                  {`Include ${passwordRulesWeak.map(rule => {
-                    return ` ${rule.message.toLowerCase()}`;
-                  })}`}
-                </Text>
-              }
+              help={`Include ${passwordRulesWeak.map(rule => {
+                return ` ${rule.message.toLowerCase()}`;
+              })}`}
               validate={passwordRulesWeak}
             >
               <TextInput

--- a/aries-site/src/examples/templates/forms/FilterExample.js
+++ b/aries-site/src/examples/templates/forms/FilterExample.js
@@ -89,7 +89,9 @@ export const FilterExample = () => {
             </FormField>
             {serverTypes && (
               <Box gap="xsmall" margin={{ top: 'medium' }}>
-                <Text margin={{ left: 'small' }}>HPE Server Types</Text>
+                <Text color="text-weak" size="xsmall">
+                  HPE Server Types
+                </Text>
                 <Box border gap="small" pad="xsmall" round="xsmall">
                   {serverTypes.map(server => {
                     return (
@@ -101,7 +103,9 @@ export const FilterExample = () => {
             )}
             {sellers && (
               <Box gap="xsmall" margin={{ top: 'medium' }}>
-                <Text margin={{ left: 'small' }}>Seller</Text>
+                <Text color="text-weak" size="xsmall">
+                  Seller
+                </Text>
                 <Box border gap="small" pad="xsmall" round="xsmall">
                   {sellers.map(seller => {
                     return (

--- a/aries-site/src/examples/templates/forms/SettingsExample.js
+++ b/aries-site/src/examples/templates/forms/SettingsExample.js
@@ -50,7 +50,9 @@ export const SettingsExample = () => {
             onSubmit={({ value, touched }) => onSubmit({ value, touched })}
           >
             <Box margin={{ bottom: 'small' }}>
-              <Text margin={{ left: 'small' }}>Key feature</Text>
+              <Text color="text-weak" size="xsmall">
+                Key feature
+              </Text>
               <FormField
                 name="notifications"
                 label="Notifications"
@@ -75,7 +77,9 @@ export const SettingsExample = () => {
               </FormField>
             </Box>
             <Box margin={{ bottom: 'small' }}>
-              <Text margin={{ left: 'small' }}>Key feature</Text>
+              <Text color="text-weak" size="xsmall">
+                Key feature
+              </Text>
               <FormField
                 name="doNotDisturb"
                 label="Do Not Disturb"

--- a/aries-site/src/examples/templates/forms/SignUpExample.js
+++ b/aries-site/src/examples/templates/forms/SignUpExample.js
@@ -78,12 +78,8 @@ export const SignUpExample = () => {
               label="Password"
               htmlFor="password-sign-up"
               name="password"
-              help={
-                <Text size="xsmall">
-                  Include at least 8 characters, a lowercase letter, an
-                  uppercase letter, a number, and a special character
-                </Text>
-              }
+              help="Include at least 8 characters, a lowercase letter, an
+              uppercase letter, a number, and a special character"
               validate={passwordRulesStrong}
             >
               <TextInput

--- a/aries-site/src/themes/aries.js
+++ b/aries-site/src/themes/aries.js
@@ -3,6 +3,11 @@ import { deepMerge, normalizeColor } from 'grommet/utils';
 
 export const aries = deepMerge(hpe, {
   defaultMode: 'dark',
+  global: {
+    input: {
+      weight: 500,
+    },
+  },
   layer: {
     background: 'background',
   },
@@ -22,6 +27,37 @@ export const aries = deepMerge(hpe, {
           border: 2px solid ${theme.global.colors.text.light};
           top: 0px;
         `,
+      },
+    },
+  },
+  formField: {
+    label: {
+      size: 'xsmall',
+      color: 'text-weak',
+      margin: {
+        horizontal: 'none',
+      },
+    },
+    error: {
+      size: 'xsmall',
+      color: 'text-xweak',
+      margin: {
+        start: 'none',
+      },
+    },
+    help: {
+      size: 'xsmall',
+      color: 'text-xweak',
+      margin: {
+        start: 'none',
+        bottom: 'xsmall',
+      },
+    },
+    info: {
+      size: 'xsmall',
+      color: 'text-xweak',
+      margin: {
+        start: 'none',
       },
     },
   },
@@ -57,6 +93,14 @@ export const aries = deepMerge(hpe, {
     fontWeight: 500,
     hover: {
       textDecoration: 'underline',
+    },
+  },
+  textInput: {
+    fontWeight: 500,
+    placeholder: {
+      extend: () => `
+          font-weight: 500;
+      `,
     },
   },
 });

--- a/aries-site/src/themes/aries.js
+++ b/aries-site/src/themes/aries.js
@@ -95,14 +95,6 @@ export const aries = deepMerge(hpe, {
       textDecoration: 'underline',
     },
   },
-  textInput: {
-    fontWeight: 500,
-    placeholder: {
-      extend: () => `
-          font-weight: 500;
-      `,
-    },
-  },
 });
 
 export const { colors } = aries.global;

--- a/aries-site/src/themes/aries.js
+++ b/aries-site/src/themes/aries.js
@@ -4,10 +4,11 @@ import { deepMerge, normalizeColor } from 'grommet/utils';
 export const aries = deepMerge(hpe, {
   defaultMode: 'dark',
   global: {
+    colors: {
+      focus: 'teal!'
+    },
     input: {
       weight: 500,
-    colors: {
-      focus: 'teal!',
     },
   },
   layer: {


### PR DESCRIPTION
Preview: https://deploy-preview-504--keen-mayer-a86c8b.netlify.com/templates/forms

This PR updates formfield label, help, info, error, and placeholder styles.

One note: As is, FormField labels have a vertical margin of `xsmall`. I've added the same as the bottom margin to help text to create the same spacing between the text and the formfield. However, in instances where there is label + help text, the label still has the vertical margin which seems to push it a little too far away from the help text.
Just label:
 <img width="348" alt="Screen Shot 2020-03-12 at 10 45 14 AM" src="https://user-images.githubusercontent.com/12522275/76550213-fe021f00-644e-11ea-8b7f-933ccf70b6f3.png">
Label + help text:
<img width="360" alt="Screen Shot 2020-03-12 at 10 45 21 AM" src="https://user-images.githubusercontent.com/12522275/76550224-00fd0f80-644f-11ea-8b2b-f98f143dec4e.png">

- Ideally: We could just add top margin to the formfield component/child, then have no margin on labels or help text and let the line height create the spacing. -- however, as of now we can't

Options with current theme styling options:
- Leave as is
- Remove any margin on label and help text (would put the text essentially right on the formfield border but the spacing between the label and help text would be correct)
- Is there a way to check if there is label + help prop on formfield and if it's only label, put the bottom margin on the label?

Closes #497 
Closes #496 