### PR TITLE
Customize Form

### DIFF
--- a/aries-site/src/data/structure.js
+++ b/aries-site/src/data/structure.js
@@ -270,6 +270,12 @@ export const structure = [
       'Common form use cases from application configuration to payment acceptance.',
     icon: size => <IconBrand size={size} />,
     seoDescription: 'HPE Design System form examples and templates.',
-    sections: ['Sign In', 'Sign Up', 'Change Password', 'Settings'],
+    sections: [
+      'Sign In',
+      'Sign Up',
+      'Change Password',
+      'Settings',
+      'Customize',
+    ],
   },
 ];

--- a/aries-site/src/examples/templates/forms/CustomizeExample.js
+++ b/aries-site/src/examples/templates/forms/CustomizeExample.js
@@ -1,0 +1,134 @@
+import React from 'react';
+import {
+  Anchor,
+  Box,
+  Button,
+  Form,
+  FormField,
+  Header,
+  Heading,
+  RadioButtonGroup,
+  Text,
+} from 'grommet';
+import { FormContainer } from '.';
+
+export const CustomizeExample = () => {
+  const [formValues, setFormValues] = React.useState({});
+
+  // eslint-disable-next-line no-unused-vars
+  const onSubmit = ({ value, touched }) => {
+    // Your submission logic here
+  };
+
+  return (
+    <FormContainer width="medium">
+      <Box gap="medium">
+        <Header
+          direction="column"
+          align="start"
+          gap="xxsmall"
+          pad={{ horizontal: 'xxsmall' }}
+        >
+          <Heading level={3} margin="none">
+            Customize
+          </Heading>
+          <Text>your HPE Edgeline Server </Text>
+        </Header>
+        <Box
+          // Padding used to prevent focus from being cutoff
+          pad={{ horizontal: 'xxsmall' }}
+        >
+          <Form
+            validate="blur"
+            value={formValues}
+            onChange={setFormValues}
+            onSubmit={({ value, touched }) => onSubmit({ value, touched })}
+          >
+            <FormField
+              label={
+                <Heading level={4} margin="none">
+                  Memory
+                </Heading>
+              }
+              help={
+                <Anchor href="#" size="xsmall">
+                  How much memory does my server need?
+                </Anchor>
+              }
+              htmlFor="memory"
+              name="memory"
+            >
+              <RadioButtonGroup
+                name="memory"
+                options={[
+                  '8GB (1x8GB) DDR4-2400 ECC memory',
+                  '32GB (2x16GB) DDR4-2400 ECC memory',
+                  '64GB (2x32GB) DDR4-2400 ECC memory',
+                ]}
+              >
+                {(option, { checked, hover }) => {
+                  let border;
+                  if (checked) border = { color: 'brand', side: 'all' };
+                  else if (hover) border = { color: 'active', side: 'all' };
+                  else border = 'text-weak';
+                  return (
+                    <Box
+                      border={border}
+                      pad={{ horizontal: 'small', vertical: 'xsmall' }}
+                      round="xsmall"
+                    >
+                      {option}
+                    </Box>
+                  );
+                }}
+              </RadioButtonGroup>
+            </FormField>
+            <FormField
+              label={
+                <Heading level={4} margin="none">
+                  CPU
+                </Heading>
+              }
+              help={
+                <Anchor href="#" size="xsmall">
+                  What is the right processor for my workload?
+                </Anchor>
+              }
+              htmlFor="cpu"
+              name="cpu"
+            >
+              <RadioButtonGroup
+                name="cpu"
+                options={[
+                  'AMD Opteron™ 1.6GHz (Turbo Boost 2.8GHz), 4 cores, 6 ' +
+                    'graphic cores, 1MB',
+                  'AMD Opteron™ 2.1GHz (Turbo Boost 3.4GHz), 4 cores, 8 ' +
+                    'graphic cores, 2MB',
+                ]}
+              >
+                {(option, { checked, hover }) => {
+                  let border;
+                  if (checked) border = { color: 'brand', side: 'all' };
+                  else if (hover) border = { color: 'active', side: 'all' };
+                  else border = 'text-weak';
+                  return (
+                    <Box
+                      border={border}
+                      pad={{ horizontal: 'small', vertical: 'xsmall' }}
+                      round="xsmall"
+                    >
+                      {option}
+                    </Box>
+                  );
+                }}
+              </RadioButtonGroup>
+            </FormField>
+            <Box align="start" margin={{ top: 'medium', bottom: 'small' }}>
+              <Button label="Continue" primary type="submit" />
+            </Box>
+          </Form>
+        </Box>
+      </Box>
+    </FormContainer>
+  );
+};

--- a/aries-site/src/examples/templates/forms/CustomizeExample.js
+++ b/aries-site/src/examples/templates/forms/CustomizeExample.js
@@ -70,7 +70,7 @@ export const CustomizeExample = () => {
                   let border;
                   if (checked) border = { color: 'brand', side: 'all' };
                   else if (hover) border = { color: 'active', side: 'all' };
-                  else border = 'text-weak';
+                  else border = { color: border, side: 'all' };
                   return (
                     <Box
                       border={border}
@@ -110,7 +110,7 @@ export const CustomizeExample = () => {
                   let border;
                   if (checked) border = { color: 'brand', side: 'all' };
                   else if (hover) border = { color: 'active', side: 'all' };
-                  else border = 'text-weak';
+                  else border = { color: border, side: 'all' };
                   return (
                     <Box
                       border={border}

--- a/aries-site/src/examples/templates/forms/index.js
+++ b/aries-site/src/examples/templates/forms/index.js
@@ -1,4 +1,5 @@
 export * from './ChangePasswordExample';
+export * from './CustomizeExample';
 export * from './FilterExample';
 export * from './FormContainer';
 export * from './formHelpers';

--- a/aries-site/src/pages/templates/forms.js
+++ b/aries-site/src/pages/templates/forms.js
@@ -3,6 +3,7 @@ import React from 'react';
 import { Meta, SubsectionText } from '../../components';
 import {
   ChangePasswordExample,
+  CustomizeExample,
   FilterExample,
   SettingsExample,
   SignInExample,
@@ -79,6 +80,16 @@ const Forms = () => {
             figma="https://www.figma.com/file/K0PppsSh6aQSszqlwKAekg/hpe-design-system-stickers?node-id=267%3A77"
           >
             <SettingsExample />
+          </Example>
+        </Subsection>
+      </ContentSection>
+      <ContentSection>
+        <Subsection name="Customize">
+          <Example
+            code="https://raw.githubusercontent.com/hpe-design/design-system/master/aries-site/src/examples/templates/forms/CustomizeExample.js"
+            figma="https://www.figma.com/file/K0PppsSh6aQSszqlwKAekg/hpe-design-system-stickers?node-id=259%3A87"
+          >
+            <CustomizeExample />
           </Example>
         </Subsection>
       </ContentSection>


### PR DESCRIPTION
Preview: https://deploy-preview-505--keen-mayer-a86c8b.netlify.com/templates/forms#customize

[Design](https://www.figma.com/file/K0PppsSh6aQSszqlwKAekg/hpe-design-system-stickers?node-id=259%3A87)

## Notes on differences
- Currently, we are implementing all form elements within the `FormField` component which has a border (causing the outer border here). As discussed on Tuesday's call, that outer border should be receiving the focus indicator and items within should just receiving hover/active styling. This Customize Form design differs from the discussed behavior in that it is showing the focus around individual elements. @L0ZZI any design direction here?

- There is also an issue when Help text is an Anchor. When I tab into the form field, both the anchor and the formfield look like they have focus (even though anchor is the active element, I would have to tab again to get to the formfield input):
<img width="369" alt="Screen Shot 2020-03-11 at 1 33 11 PM" src="https://user-images.githubusercontent.com/12522275/76554059-6b637f00-6452-11ea-9c8b-8cae309875fa.png">

Closes #478 
