### PR TITLE
Use teal! for focus color

### DIFF
--- a/aries-site/src/themes/aries.js
+++ b/aries-site/src/themes/aries.js
@@ -3,6 +3,11 @@ import { deepMerge, normalizeColor } from 'grommet/utils';
 
 export const aries = deepMerge(hpe, {
   defaultMode: 'dark',
+  global: {
+    colors: {
+      focus: 'teal!',
+    },
+  },
   layer: {
     background: 'background',
   },


### PR DESCRIPTION
Update focus color to use `teal!`

Design: https://www.figma.com/file/K0PppsSh6aQSszqlwKAekg/hpe-design-system-stickers?node-id=251%3A435

Closes #527 