### PR TITLE
Update button primary text color

### DIFF
--- a/aries-site/src/themes/aries.js
+++ b/aries-site/src/themes/aries.js
@@ -11,6 +11,10 @@ export const aries = deepMerge(hpe, {
       weight: 500,
     },
   },
+  button: {
+    color: props =>
+      props.primary ? '#FFFFFF' : normalizeColor('text', props.theme),
+  },
   layer: {
     background: 'background',
   },


### PR DESCRIPTION
Preview: TBD

If a button is a primary button, it should always have text color of #FFFFFF, but otherwise we want to respect the text color and support the dark/light differences.

Closes #509 