### PR TITLE
Changed ignored files to include Layout files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,7 +9,7 @@
 
 # production
 *dist
-*out
+*/out
 *.next
 *storybook-static
 


### PR DESCRIPTION
Currently, files/directories that have the suffix `out` are excluded from the committed batch.

The `*out` definition on the ignore file was needed to exclude the production outcome of running `yarn export`, but we should be more specific about the directory rather than any suffix that ends with `out` such as Layout or AppLayout files/dirs that are being ignored.

Tested with running `yarn export` to make sure the intended files are still excluded.