### PR TITLE
Update placeholder color to text-xweak

### DIFF
--- a/aries-site/src/themes/aries.js
+++ b/aries-site/src/themes/aries.js
@@ -11,6 +11,10 @@ export const aries = deepMerge(hpe, {
       weight: 500,
     },
   },
+  button: {
+    color: props =>
+      props.primary ? '#FFFFFF' : normalizeColor('text', props.theme),
+  },
   layer: {
     background: 'background',
   },

--- a/aries-site/src/themes/aries.js
+++ b/aries-site/src/themes/aries.js
@@ -6,6 +6,7 @@ export const aries = deepMerge(hpe, {
   global: {
     colors: {
       focus: 'teal!',
+      placeholder: 'text-xweak',
     },
     input: {
       weight: 500,


### PR DESCRIPTION
Based on this issue: https://github.com/hpe-design/design-system/issues/508

Color contrast for placeholder text is not flagged for contrast -- what is important is that the context of the formfield design can be discerned via screenreader or other form context such as labels so the user doesn't have to rely solely on the placeholder text.

Closes #508 