### PR TITLE
Update anchor style in theme

### DIFF
--- a/aries-site/src/themes/aries.js
+++ b/aries-site/src/themes/aries.js
@@ -91,8 +91,8 @@ export const aries = deepMerge(hpe, {
     },
   },
   anchor: {
-    color: 'brand',
-    textDecoration: 'none',
+    color: 'text',
+    textDecoration: 'underline',
     fontWeight: 500,
     hover: {
       textDecoration: 'underline',


### PR DESCRIPTION
Update anchor style to match what is shown here: https://www.figma.com/file/I7PsiUmvr7OEJ6311rBUfg/hpe-design-system-library-anchor?node-id=0%3A1

Some elements on the site that are currently `Anchors`, should now be plain/normalized Buttons -- these changes will come in a separate PR.

Closes #539 