### PR TITLE
Update button color to not use normalizeColor

### DIFF
--- a/aries-site/src/themes/aries.js
+++ b/aries-site/src/themes/aries.js
@@ -3,6 +3,12 @@ import { deepMerge, normalizeColor } from 'grommet/utils';
 
 export const aries = deepMerge(hpe, {
   defaultMode: 'dark',
+  button: {
+    color: props =>
+      props.primary
+        ? '#FFFFFF'
+        : props.theme.global.colors.text[props.theme.dark ? 'dark' : 'light'],
+  },
   checkBox: {
     color: 'selected-text',
     gap: 'small',


### PR DESCRIPTION
Allows primary button to always be #FFFFFF but then text color otherwise.