### PR TITLE
Create Extend index page

### DIFF
--- a/aries-site/src/pages/extend/index.js
+++ b/aries-site/src/pages/extend/index.js
@@ -1,0 +1,56 @@
+import React from 'react';
+import Link from 'next/link';
+import { Box, Heading, Paragraph } from 'grommet';
+
+import { CardGrid, ContentCard, Meta } from '../../components';
+import { Layout, PageIntro } from '../../layouts';
+import { getCards, getPageDetails, nameToPath, useDarkMode } from '../../utils';
+
+const title = 'Extend';
+const pageDetails = getPageDetails(title);
+const cards = getCards(title);
+
+const Extend = () => {
+  const darkMode = useDarkMode();
+  const cardImage = darkMode.value
+    ? '/carte-extend-dark.svg'
+    : '/carte-extend-light.svg';
+
+  return (
+    <Layout title={title} isLanding>
+      <Meta
+        title={title}
+        description={pageDetails.seoDescription}
+        canonicalUrl="https://design-system.hpe.design/extend"
+      />
+      <Box gap="large">
+        <PageIntro
+          image={{
+            src: cardImage,
+            alt: 'Card deck of HPE Design System component cards',
+            fit: 'cover',
+          }}
+        >
+          <Box justify="center" fill>
+            <Heading margin="none">{title}</Heading>
+            <Paragraph fill>{pageDetails.description}</Paragraph>
+          </Box>
+        </PageIntro>
+        <CardGrid>
+          {cards.map(topic => (
+            // Need to pass href because of: https://github.com/zeit/next.js/#forcing-the-link-to-expose-href-to-its-child
+            <Link key={topic.name} href={nameToPath(topic.name)} passHref>
+              <ContentCard
+                as="a"
+                style={{ textDecoration: 'none' }}
+                topic={topic}
+              />
+            </Link>
+          ))}
+        </CardGrid>
+      </Box>
+    </Layout>
+  );
+};
+
+export default Extend;

--- a/aries-site/src/pages/extend/index.js
+++ b/aries-site/src/pages/extend/index.js
@@ -27,7 +27,7 @@ const Extend = () => {
         <PageIntro
           image={{
             src: cardImage,
-            alt: 'Card deck of HPE Design System component cards',
+            alt: 'Card deck of HPE Design System extend cards',
             fit: 'cover',
           }}
         >


### PR DESCRIPTION
Creates the index page for Extend. Regarding the subpages, we will need clarification if these will have their own pages or they will be external links to those sites.