### PR TITLE
Minor tweaks to CardGrid layout

### DIFF
--- a/aries-core/src/js/components/core/Tile/Tile.js
+++ b/aries-core/src/js/components/core/Tile/Tile.js
@@ -18,7 +18,7 @@ export const Tile = forwardRef(({ children, heading, pad, ...rest }, ref) => {
           </Heading>
         </Header>
       )}
-      <Box flex pad={tilePad}>
+      <Box flex pad={tilePad} fill>
         {children}
       </Box>
     </Box>

--- a/aries-site/src/components/content/CardGrid.js
+++ b/aries-site/src/components/content/CardGrid.js
@@ -1,10 +1,17 @@
-import React from 'react';
+import React, { useContext } from 'react';
 import PropTypes from 'prop-types';
-import { Grid } from 'grommet';
+import { Grid, ResponsiveContext } from 'grommet';
 
 export const CardGrid = ({ children, ...rest }) => {
+  const size = useContext(ResponsiveContext);
   return (
-    <Grid columns="medium" gap="medium" justify="center" fill {...rest}>
+    <Grid
+      columns={size !== 'small' ? 'medium' : '100%'}
+      gap="medium"
+      justify="center"
+      fill
+      {...rest}
+    >
       {children}
     </Grid>
   );


### PR DESCRIPTION
Noticed a few issues with CardGrid, this gives fixes:
1. On mobile, the width of medium was too wide, so the padding wasn't being respected:
<img width="448" alt="Screen Shot 2020-03-27 at 9 56 16 AM" src="https://user-images.githubusercontent.com/12522275/77780503-56214f80-7011-11ea-8493-9913fe3e39bb.png">

2. The inner Tile box couldn't be controlled by props of ContentCard, but in some cases the content was unable to take the full width, so this fix is in Tile:
<img width="478" alt="Screen Shot 2020-03-27 at 9 05 24 AM" src="https://user-images.githubusercontent.com/12522275/77780488-515c9b80-7011-11ea-8fbe-ef1a2b99e85d.png">

