### PR TITLE
Center examples in Example and allow Fullscreen on everything

### DIFF
--- a/aries-site/src/examples/components/layouts/GridExample.js
+++ b/aries-site/src/examples/components/layouts/GridExample.js
@@ -3,32 +3,32 @@ import { Box, Grid, Text } from 'grommet';
 
 export const GridExample = () => {
   return (
-      <Grid
-        rows={['xxsmall', 'small', 'xxsmall']}
-        columns={['1/4', '3/4']}
-        areas={[
-          ['header', 'header'],
-          ['sidebar', 'main'],
-          ['footer', 'footer'],
-        ]}
-        gap="small"
-        fill
-      >
-        <Box background="green" gridArea="header" justify="center" pad="small">
-          <Text weight="bold">Header</Text>
-        </Box>
+    <Grid
+      rows={['xxsmall', 'flex', 'xxsmall']}
+      columns={['1/4', '3/4']}
+      areas={[
+        ['header', 'header'],
+        ['sidebar', 'main'],
+        ['footer', 'footer'],
+      ]}
+      gap="small"
+      fill
+    >
+      <Box background="green" gridArea="header" justify="center" pad="small">
+        <Text weight="bold">Header</Text>
+      </Box>
 
-        <Box background="yellow" gridArea="sidebar" pad="small">
-          <Text weight="bold">Sidebar</Text>
-        </Box>
+      <Box background="yellow" gridArea="sidebar" pad="small">
+        <Text weight="bold">Sidebar</Text>
+      </Box>
 
-        <Box background="blue" gridArea="main" pad="small">
-          <Text weight="bold">Main</Text>
-        </Box>
+      <Box background="blue" gridArea="main" pad="small">
+        <Text weight="bold">Main</Text>
+      </Box>
 
-        <Box background="green" gridArea="footer" justify="center" pad="small">
-          <Text weight="bold">Footer</Text>
-        </Box>
-      </Grid>
+      <Box background="green" gridArea="footer" justify="center" pad="small">
+        <Text weight="bold">Footer</Text>
+      </Box>
+    </Grid>
   );
 };

--- a/aries-site/src/layouts/content/Example.js
+++ b/aries-site/src/layouts/content/Example.js
@@ -115,12 +115,14 @@ export const Example = ({
       <Box margin={{ vertical: 'small' }} gap="large">
         <Box>
           <Box
-            direction="row"
+            align={!template ? 'center' : undefined}
             background="background-front"
-            pad={template ? { horizontal: 'large', top: 'large' } : 'large'}
+            direction="row"
             // Height for template screen needs to be between medium and large
             // to maintain aspect ratio, so this is small + medium
-            height={template ? '576px' : undefined}
+            height={template ? '576px' : { min: '576px' }}
+            justify="center"
+            pad={template ? { horizontal: 'large', top: 'large' } : 'large'}
             round={
               designer || docs || figma || template
                 ? { corner: 'top', size: 'small' }

--- a/aries-site/src/layouts/content/Example.js
+++ b/aries-site/src/layouts/content/Example.js
@@ -1,7 +1,15 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
-import { Box, Button, Keyboard, Layer, Text, ThemeContext } from 'grommet';
+import {
+  Box,
+  Button,
+  defaultProps,
+  Keyboard,
+  Layer,
+  Text,
+  ThemeContext,
+} from 'grommet';
 import { Contract, Desktop } from 'grommet-icons';
 import Prism from 'prismjs';
 import {
@@ -91,6 +99,9 @@ export const Example = ({
   const [mobile, setMobile] = React.useState(false);
   const [showLayer, setShowLayer] = React.useState(false);
   const codeRef = React.useRef();
+  const { size } = defaultProps.theme.global;
+  const aspectHeight = `${parseInt(size.medium, 10) +
+    parseInt(size.small, 10)}px`;
 
   React.useEffect(() => {
     if (codeOpen && !codeText) {
@@ -120,7 +131,7 @@ export const Example = ({
             direction="row"
             // Height for template screen needs to be between medium and large
             // to maintain aspect ratio, so this is small + medium
-            height={template ? '576px' : { min: '576px' }}
+            height={template ? aspectHeight : { min: aspectHeight }}
             justify="center"
             pad={template ? { horizontal: 'large', top: 'large' } : 'large'}
             round={

--- a/aries-site/src/layouts/content/Example.js
+++ b/aries-site/src/layouts/content/Example.js
@@ -182,36 +182,38 @@ export const Example = ({
             <Box fill background="background-front">
               <Box
                 direction="row"
-                justify="between"
+                justify={template ? 'between' : 'end'}
                 pad="xxsmall"
                 background="#111"
               >
-                <Box direction="row">
-                  <Box
-                    title="Desktop layout"
-                    background={!mobile ? 'background-contrast' : undefined}
-                    direction="row"
-                    pad="small"
-                    align="center"
-                    gap="small"
-                    onClick={() => setMobile(false)}
-                  >
-                    <Desktop />
-                    <Text>Desktop</Text>
+                {template && (
+                  <Box direction="row">
+                    <Box
+                      title="Desktop layout"
+                      background={!mobile ? 'background-contrast' : undefined}
+                      direction="row"
+                      pad="small"
+                      align="center"
+                      gap="small"
+                      onClick={() => setMobile(false)}
+                    >
+                      <Desktop />
+                      <Text>Desktop</Text>
+                    </Box>
+                    <Box
+                      title="Mobile layout"
+                      background={mobile ? 'background-contrast' : undefined}
+                      direction="row"
+                      pad="small"
+                      align="center"
+                      gap="small"
+                      onClick={() => setMobile(true)}
+                    >
+                      <IconMobile />
+                      <Text>Mobile</Text>
+                    </Box>
                   </Box>
-                  <Box
-                    title="Mobile layout"
-                    background={mobile ? 'background-contrast' : undefined}
-                    direction="row"
-                    pad="small"
-                    align="center"
-                    gap="small"
-                    onClick={() => setMobile(true)}
-                  >
-                    <IconMobile />
-                    <Text>Mobile</Text>
-                  </Box>
-                </Box>
+                )}
                 <Button
                   title="Leave full screen"
                   icon={<Contract />}
@@ -222,7 +224,13 @@ export const Example = ({
                   hoverIndicator
                 />
               </Box>
-              <Box direction="row" justify="center" flex {...rest}>
+              <Box
+                direction="row"
+                justify="center"
+                align={!template ? 'center' : undefined}
+                flex
+                {...rest}
+              >
                 {children &&
                   React.cloneElement(children, {
                     mobile,

--- a/aries-site/src/layouts/content/ExampleControls.js
+++ b/aries-site/src/layouts/content/ExampleControls.js
@@ -24,13 +24,7 @@ ControlButton.propTypes = {
     .isRequired,
 };
 
-export const ExampleControls = ({
-  designer,
-  docs,
-  figma,
-  setShowLayer,
-  template,
-}) => (
+export const ExampleControls = ({ designer, docs, figma, setShowLayer }) => (
   <Box
     background="background-front"
     border={{
@@ -63,12 +57,10 @@ export const ExampleControls = ({
         </ControlButton>
       )}
     </Box>
-    {template && (
-      <ControlButton onClick={() => setShowLayer(true)}>
-        <Expand />
-        <Text weight="bold">See Fullscreen</Text>
-      </ControlButton>
-    )}
+    <ControlButton onClick={() => setShowLayer(true)}>
+      <Expand />
+      <Text weight="bold">See Fullscreen</Text>
+    </ControlButton>
   </Box>
 );
 
@@ -76,6 +68,5 @@ ExampleControls.propTypes = {
   designer: PropTypes.string,
   docs: PropTypes.string,
   figma: PropTypes.string,
-  template: PropTypes.bool,
   setShowLayer: PropTypes.func,
 };


### PR DESCRIPTION
Preview: 
This sets a height of `576px` for the Examples (a height previously determined as optimal for aspect ratio of full-screen templates). However, in the case of non-template, we are using a min-height of 576px since some forms are longer than this and would be cut off otherwise.

Now, any example is given a fullscreen option. However, "Desktop, Mobile" toggle is still reserved for templates.

Design:
<img width="522" alt="Screen Shot 2020-03-27 at 10 31 35 AM" src="https://user-images.githubusercontent.com/12522275/77783506-36405a80-7016-11ea-92ce-83e710daf410.png">

Closes #585 