### PR TITLE
Collapsible section / Usage example enhancement

### DIFF
--- a/aries-site/src/components/content/CollapsibleSection.js
+++ b/aries-site/src/components/content/CollapsibleSection.js
@@ -1,10 +1,16 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
 import { Box, Collapsible, Text } from 'grommet';
 import { FormUp, FormDown } from 'grommet-icons';
 
 export const CollapsibleSection = ({ label, onClick, ...rest }) => {
   const [open, setOpen] = useState(false);
+  const [labelText, setLabelText] = useState();
+
+  useEffect(() => {
+    setLabelText(open ? label.open || label : label.closed || label);
+  }, [label, open, setLabelText]);
+
   return (
     <>
       <Box
@@ -20,7 +26,7 @@ export const CollapsibleSection = ({ label, onClick, ...rest }) => {
         round={!open ? 'small' : { corner: 'top', size: 'small' }}
       >
         {!open ? <FormDown /> : <FormUp />}
-        <Text weight="bold">{label}</Text>
+        <Text weight="bold">{labelText}</Text>
       </Box>
       <Collapsible open={open}>
         <Box
@@ -38,6 +44,12 @@ export const CollapsibleSection = ({ label, onClick, ...rest }) => {
 };
 
 CollapsibleSection.propTypes = {
-  label: PropTypes.string,
+  label: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.shape({
+      closed: PropTypes.string,
+      open: PropTypes.string,
+    }),
+  ]),
   onClick: PropTypes.func,
 };

--- a/aries-site/src/components/content/SubsectionText.js
+++ b/aries-site/src/components/content/SubsectionText.js
@@ -19,7 +19,11 @@ export const SubsectionText = ({ level, size, ...rest }) => {
 };
 
 SubsectionText.propTypes = {
-  children: PropTypes.oneOfType([PropTypes.string, PropTypes.array]),
+  children: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.array,
+    PropTypes.element,
+  ]),
   level: PropTypes.number,
   size: PropTypes.string,
 };

--- a/aries-site/src/layouts/content/Example.js
+++ b/aries-site/src/layouts/content/Example.js
@@ -245,7 +245,9 @@ Example.propTypes = {
       href: PropTypes.string,
     }),
   ),
-  details: PropTypes.arrayOf(PropTypes.string),
+  details: PropTypes.arrayOf(
+    PropTypes.oneOfType([PropTypes.string, PropTypes.element]),
+  ),
   designer: PropTypes.string,
   docs: PropTypes.string,
   figma: PropTypes.string,

--- a/aries-site/src/layouts/content/Example.js
+++ b/aries-site/src/layouts/content/Example.js
@@ -145,7 +145,9 @@ export const Example = ({
         </Box>
         <Box gap="medium">
           {details && (
-            <CollapsibleSection label="Show Details">
+            <CollapsibleSection
+              label={{ closed: 'Show Details', open: 'Hide Details' }}
+            >
               {details.map((item, index) => (
                 <SubsectionText key={index} level={1}>
                   {item}
@@ -155,8 +157,8 @@ export const Example = ({
           )}
           {code && (
             <CollapsibleSection
-              label="Show Code"
-              onClick={() => setCodeOpen(true)}
+              label={{ closed: 'Show Code', open: 'Hide Code' }}
+              onClick={() => setCodeOpen(!codeOpen)}
             >
               <Text size="xsmall" color="text">
                 <Syntax>


### PR DESCRIPTION
Two enhancements to the `<CollapsibleSection>` piece of `<Example>`:

1. Added a label toggle so that we can display different text based on open or closed section state.
  - Accepts either a string or and object `{closed: 'label when closed', open: 'label when open'}`
2. Extended Details to accept a React element in addition to just strings. This allows for situations where we might want an inline `Anchor` or need for a more complex description.