### PR TITLE
Create placholder pages for Extend section

### DIFF
--- a/aries-site/src/components/content/ComingSoon.js
+++ b/aries-site/src/components/content/ComingSoon.js
@@ -26,7 +26,7 @@ export const ComingSoon = () => {
           <Text size={textSize}>Carte Design System</Text>
         </Box>
         <SubsectionText>
-          The HPE Design System is the way Hewlett Packard Enterprise’s brand,
+          The HPE Carte Design System is the way Hewlett Packard Enterprise’s brand,
           technology, and its partners share a single language for application,
           web, and digitial experiences to answer your customers needs—Look
           behind the element!

--- a/aries-site/src/components/content/ComingSoon.js
+++ b/aries-site/src/components/content/ComingSoon.js
@@ -23,7 +23,7 @@ export const ComingSoon = () => {
           <Text size={textSize} weight="bold">
             HPE
           </Text>
-          <Text size={textSize}>Design System</Text>
+          <Text size={textSize}>Carte Design System</Text>
         </Box>
         <SubsectionText>
           The HPE Design System is the way Hewlett Packard Enterprise’s brand,

--- a/aries-site/src/components/content/ComingSoon.js
+++ b/aries-site/src/components/content/ComingSoon.js
@@ -2,7 +2,7 @@ import React from 'react';
 import Link from 'next/link';
 import { Box, Text, Anchor } from 'grommet';
 import { ContentSection } from '../../layouts';
-import { SubmitFeedback } from '.';
+import { SubsectionText } from '.';
 
 export const ComingSoon = () => {
   const textSize = 'xxlarge';
@@ -18,32 +18,22 @@ export const ComingSoon = () => {
           This page appears to be empty, but content will be coming soon!
         </Text>
       </ContentSection>
-      <ContentSection lastSection>
+      <ContentSection>
         <Box direction="row" gap="small">
           <Text size={textSize} weight="bold">
             HPE
           </Text>
           <Text size={textSize}>Design System</Text>
         </Box>
-        <Text>
+        <SubsectionText>
           The HPE Design System is the way Hewlett Packard Enterprise’s brand,
           technology, and its partners share a single language for application,
           web, and digitial experiences to answer your customers needs—Look
           behind the element!
-        </Text>
-        <Text>
-          Something missing or looking for more information? Get in touch to
-          help make the HPE Design System better.
-        </Text>
-        <Box direction="row-responsive" gap="medium" align="center">
-          <SubmitFeedback />
-          <Text>or</Text>
-          <Box>
-            <Link href="/" passHref>
-              <Anchor color="text" label="Take me back to the Homepage" />
-            </Link>
-          </Box>
-        </Box>
+        </SubsectionText>
+        <Link href="/" passHref>
+          <Anchor label="Take me back to the Homepage" />
+        </Link>
       </ContentSection>
     </>
   );

--- a/aries-site/src/pages/extend/api-chomp.js
+++ b/aries-site/src/pages/extend/api-chomp.js
@@ -1,0 +1,27 @@
+import React from 'react';
+
+import { ComingSoon, Meta } from '../../components';
+import { ContentSection, Layout, Subsection } from '../../layouts';
+import { getPageDetails } from '../../utils';
+
+const title = 'API Chomp';
+const topic = 'Extend';
+const pageDetails = getPageDetails(title);
+
+const APIChomp = () => {
+  return (
+    <Layout title={title}>
+      <Meta
+        title={title}
+        description={pageDetails.seoDescription}
+        canonicalUrl="https://design-system.hpe.design/extend/api-chomp"
+      />
+      <ContentSection>
+        <Subsection name={title} level={1} topic={topic} />
+      </ContentSection>
+      <ComingSoon />
+    </Layout>
+  );
+};
+
+export default APIChomp;

--- a/aries-site/src/pages/extend/designer.js
+++ b/aries-site/src/pages/extend/designer.js
@@ -1,0 +1,27 @@
+import React from 'react';
+
+import { ComingSoon, Meta } from '../../components';
+import { ContentSection, Layout, Subsection } from '../../layouts';
+import { getPageDetails } from '../../utils';
+
+const title = 'Designer';
+const topic = 'Extend';
+const pageDetails = getPageDetails(title);
+
+const Designer = () => {
+  return (
+    <Layout title={title}>
+      <Meta
+        title={title}
+        description={pageDetails.seoDescription}
+        canonicalUrl="https://design-system.hpe.design/extend/designer"
+      />
+      <ContentSection>
+        <Subsection name={title} level={1} topic={topic} />
+      </ContentSection>
+      <ComingSoon />
+    </Layout>
+  );
+};
+
+export default Designer;

--- a/aries-site/src/pages/extend/global-sidebar.js
+++ b/aries-site/src/pages/extend/global-sidebar.js
@@ -1,0 +1,27 @@
+import React from 'react';
+
+import { ComingSoon, Meta } from '../../components';
+import { ContentSection, Layout, Subsection } from '../../layouts';
+import { getPageDetails } from '../../utils';
+
+const title = 'Global Sidebar';
+const topic = 'Extend';
+const pageDetails = getPageDetails(title);
+
+const GlobalSidebar = () => {
+  return (
+    <Layout title={title}>
+      <Meta
+        title={title}
+        description={pageDetails.seoDescription}
+        canonicalUrl="https://design-system.hpe.design/extend/global-sidebar"
+      />
+      <ContentSection>
+        <Subsection name={title} level={1} topic={topic} />
+      </ContentSection>
+      <ComingSoon />
+    </Layout>
+  );
+};
+
+export default GlobalSidebar;

--- a/aries-site/src/pages/extend/hpe-audience.js
+++ b/aries-site/src/pages/extend/hpe-audience.js
@@ -1,0 +1,27 @@
+import React from 'react';
+
+import { ComingSoon, Meta } from '../../components';
+import { ContentSection, Layout, Subsection } from '../../layouts';
+import { getPageDetails } from '../../utils';
+
+const title = 'HPE Audience';
+const topic = 'Extend';
+const pageDetails = getPageDetails(title);
+
+const HPEAudience = () => {
+  return (
+    <Layout title={title}>
+      <Meta
+        title={title}
+        description={pageDetails.seoDescription}
+        canonicalUrl="https://design-system.hpe.design/extend/hpe-audience"
+      />
+      <ContentSection>
+        <Subsection name={title} level={1} topic={topic} />
+      </ContentSection>
+      <ComingSoon />
+    </Layout>
+  );
+};
+
+export default HPEAudience;

--- a/aries-site/src/pages/extend/hpe-docs.js
+++ b/aries-site/src/pages/extend/hpe-docs.js
@@ -1,0 +1,27 @@
+import React from 'react';
+
+import { ComingSoon, Meta } from '../../components';
+import { ContentSection, Layout, Subsection } from '../../layouts';
+import { getPageDetails } from '../../utils';
+
+const title = 'HPE Docs';
+const topic = 'Extend';
+const pageDetails = getPageDetails(title);
+
+const HPEDocs = () => {
+  return (
+    <Layout title={title}>
+      <Meta
+        title={title}
+        description={pageDetails.seoDescription}
+        canonicalUrl="https://design-system.hpe.design/extend/hpe-docs"
+      />
+      <ContentSection>
+        <Subsection name={title} level={1} topic={topic} />
+      </ContentSection>
+      <ComingSoon />
+    </Layout>
+  );
+};
+
+export default HPEDocs;

--- a/aries-site/src/pages/extend/hpe-images.js
+++ b/aries-site/src/pages/extend/hpe-images.js
@@ -1,0 +1,27 @@
+import React from 'react';
+
+import { ComingSoon, Meta } from '../../components';
+import { ContentSection, Layout, Subsection } from '../../layouts';
+import { getPageDetails } from '../../utils';
+
+const title = 'HPE Images';
+const topic = 'Extend';
+const pageDetails = getPageDetails(title);
+
+const HPEImages = () => {
+  return (
+    <Layout title={title}>
+      <Meta
+        title={title}
+        description={pageDetails.seoDescription}
+        canonicalUrl="https://design-system.hpe.design/extend/hpe-images"
+      />
+      <ContentSection>
+        <Subsection name={title} level={1} topic={topic} />
+      </ContentSection>
+      <ComingSoon />
+    </Layout>
+  );
+};
+
+export default HPEImages;

--- a/aries-site/src/pages/extend/table-topper.js
+++ b/aries-site/src/pages/extend/table-topper.js
@@ -1,0 +1,27 @@
+import React from 'react';
+
+import { ComingSoon, Meta } from '../../components';
+import { ContentSection, Layout, Subsection } from '../../layouts';
+import { getPageDetails } from '../../utils';
+
+const title = 'Table Topper';
+const topic = 'Extend';
+const pageDetails = getPageDetails(title);
+
+const TableTopper = () => {
+  return (
+    <Layout title={title}>
+      <Meta
+        title={title}
+        description={pageDetails.seoDescription}
+        canonicalUrl="https://design-system.hpe.design/extend/table-topper"
+      />
+      <ContentSection>
+        <Subsection name={title} level={1} topic={topic} />
+      </ContentSection>
+      <ComingSoon />
+    </Layout>
+  );
+};
+
+export default TableTopper;


### PR DESCRIPTION
Preview: https://deploy-preview-613--keen-mayer-a86c8b.netlify.com/
This creates placeholder pages so we have no dead end links on the site. It leverages the "ComingSoon" component we had made prior with a small adjustment so the feedback button was not redundant on the page.