### PR TITLE
Adds Guidance section to button page, plus enhancements to bulleted list

### DIFF
--- a/aries-site/src/components/content/BulletedList.js
+++ b/aries-site/src/components/content/BulletedList.js
@@ -13,7 +13,7 @@ export const BulletedList = ({ items, level, size }) => {
     >
       {item => (
         <Text key={item} size={size || TEXT_SIZE[level]}>
-          — {item}
+          - {item}
         </Text>
       )}
     </List>

--- a/aries-site/src/components/content/BulletedList.js
+++ b/aries-site/src/components/content/BulletedList.js
@@ -1,19 +1,32 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Text } from 'grommet';
+import { List, Text } from 'grommet';
 
-export const BulletedList = ({ items }) => {
+import { TEXT_SIZE } from '../../layouts';
+
+export const BulletedList = ({ items, level, size }) => {
   return (
-    <>
-      {items.map(item => (
-        <Text margin={{ bottom: 'xsmall' }} key={item}>
+    <List
+      data={items}
+      border={{ style: 'hidden' }}
+      pad={{ vertical: 'xxsmall' }}
+    >
+      {item => (
+        <Text key={item} size={size || TEXT_SIZE[level]}>
           — {item}
         </Text>
-      ))}
-    </>
+      )}
+    </List>
   );
 };
 
 BulletedList.propTypes = {
   items: PropTypes.arrayOf(PropTypes.string),
+  level: PropTypes.number,
+  size: PropTypes.string,
+};
+
+BulletedList.defaultProps = {
+  level: 2,
+  size: undefined,
 };

--- a/aries-site/src/components/content/SubsectionText.js
+++ b/aries-site/src/components/content/SubsectionText.js
@@ -2,13 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { Box, Paragraph } from 'grommet';
 
-// Text size should be based on if its parent heading is an
-// h2, h3, etc.
-const TEXT_SIZE = {
-  1: 'large', // heading is h1, parapgraph text should be large
-  2: 'medium', // default font size
-  3: 'small', // heading is h3, paragraph text should be small
-};
+import { TEXT_SIZE } from '../../layouts';
 
 export const SubsectionText = ({ level, size, ...rest }) => {
   return (

--- a/aries-site/src/layouts/content/Subsection.js
+++ b/aries-site/src/layouts/content/Subsection.js
@@ -6,9 +6,19 @@ import { Link as LinkIcon } from 'grommet-icons';
 import { Subheading } from '../../components';
 import { getPageDetails } from '../../utils';
 
+// Text size should be based on if its parent heading is an
+// h2, h3, etc.
+export const TEXT_SIZE = {
+  1: 'large', // heading is h1, parapgraph text should be large
+  2: 'medium', // default font size
+  3: 'small', // heading is h3, paragraph text should be small
+};
+
 export const Subsection = ({
   children,
   showHeading,
+  gap,
+  headingSize,
   level,
   name,
   topic,
@@ -46,7 +56,7 @@ export const Subsection = ({
       id={id}
       margin={{ bottom: 'small' }}
       fill="horizontal"
-      gap="medium"
+      gap={gap}
       onMouseOver={() => setOver(true)}
       onMouseOut={() => setOver(false)}
       onFocus={() => setOver(true)}
@@ -72,7 +82,9 @@ export const Subsection = ({
                   />
                 </Link>
               )}
-              <Subheading level={level}>{name}</Subheading>
+              <Subheading level={level} headingSize={headingSize}>
+                {name}
+              </Subheading>
             </Box>
             {level > 1 && (
               <Anchor
@@ -97,6 +109,8 @@ export const Subsection = ({
 Subsection.propTypes = {
   children: PropTypes.oneOfType([PropTypes.element, PropTypes.array]),
   level: PropTypes.number,
+  gap: PropTypes.string,
+  headingSize: PropTypes.string,
   name: PropTypes.string.isRequired,
   showHeading: PropTypes.bool,
   topic: PropTypes.string,
@@ -105,6 +119,8 @@ Subsection.propTypes = {
 Subsection.defaultProps = {
   children: undefined,
   level: 2,
+  gap: 'medium',
+  headingSize: undefined,
   showHeading: true,
   topic: undefined,
 };

--- a/aries-site/src/pages/components/button.js
+++ b/aries-site/src/pages/components/button.js
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { CardGrid, Meta, SubsectionText } from '../../components';
+import { BulletedList, CardGrid, Meta, SubsectionText } from '../../components';
 import { ButtonExample } from '../../examples';
 import { ContentSection, Layout, Subsection, Example } from '../../layouts';
 import { getPageDetails, getRelatedContent } from '../../utils';
@@ -30,6 +30,67 @@ const Button = () => (
         >
           <ButtonExample />
         </Example>
+      </Subsection>
+      <Subsection name="Guidance">
+        <SubsectionText>The when, how, and why to use buttons.</SubsectionText>
+      </Subsection>
+      <Subsection name="About Buttons" level={3} gap="small">
+        <SubsectionText>
+          Buttons should be used in situations where users might need to:
+        </SubsectionText>
+        <BulletedList
+          items={[
+            'Submit a form',
+            'Begin a new task',
+            'Trigger a new UI element to appear on the page',
+            'Specify a new or next step in a process',
+          ]}
+        />
+      </Subsection>
+      <Subsection name="Button Labeling" level={3} gap="small">
+        <SubsectionText>
+          Using the Carte Button Component will ensure you’re button looks like
+          a button. Applying the appropriate label is also important in making
+          sure the user has a clear understanding of what the action will do.
+        </SubsectionText>
+        <BulletedList
+          items={[
+            'Use clear and concise wording.',
+            `Avoid contractions or colloquialisms. Keep the language 
+            approachable but not personal.`,
+            'Ensure your button label matches the route destination.',
+          ]}
+        />
+      </Subsection>
+      <Subsection name="Buttons vs. Anchors" level={3} gap="small">
+        <SubsectionText>
+          The HTML elements for buttons and links (a.k.a. anchors) describe a
+          very specific type of action that is going to be taken when they are
+          used. It is important you know when to use which, as the distinction
+          matters:
+        </SubsectionText>
+        <BulletedList
+          items={[
+            `Use a link when you’re navigating to another place, such as: a 
+            "view all" page, "Jane Chen" profile, a page "skip link" etc.`,
+            `Use buttons when you are performing an action, such as: 
+            "submit," "merge," "create new," "upload," etc.`,
+            'An action is almost always occurs on the same page',
+          ]}
+        />
+      </Subsection>
+      <Subsection name="Accessibility" level={3} gap="small">
+        <SubsectionText>
+          If pressing a Button results in a new URL, or the resultant UI makes
+          sense as "a new browser tab", that is a link &lt;a&gt;. Everything
+          else is a &lt;button&gt;.
+        </SubsectionText>
+        <SubsectionText>
+          The distinction is important to screen reader users to know what's
+          going to happen next. Will I navigate somewhere or will something
+          happen on the page? So it's important to choose the right HTML element
+          for the job.
+        </SubsectionText>
       </Subsection>
       {relatedContent.length > 0 ? (
         <Subsection name="Related">


### PR DESCRIPTION
Related Issues: https://github.com/hpe-design/design-system/issues/623

[Preview](https://deploy-preview-625--keen-mayer-a86c8b.netlify.com/components/button#guidance)

Work Included:
- Updated `BulletedList` to use Grommet `List`
  - This ensures the list is rendered semantically correct in the DOM as `ul` and `li` , plus aligns with Grommet
- Maintains text size consistency in `Subsection`s by reusing the `TEXT_SIZE` concept currently applied to `SubsectionText` and applies it to `BulletedList`
- Allows `Subheading` sizes to specified should it need to be adjusted from the default
- Adds content for the "Guidance" section to `button.js`

![Screen Shot 2020-03-31 at 4 45 33 PM](https://user-images.githubusercontent.com/1756948/78081963-1939bd80-736f-11ea-8d56-30c168714db4.png)
