### PR TITLE
Fix key warning -- move footer link keys up

### DIFF
--- a/aries-site/src/layouts/main/Footer.js
+++ b/aries-site/src/layouts/main/Footer.js
@@ -37,8 +37,8 @@ export const Footer = () => {
         </Box>
         <Box direction="row" gap="xsmall">
           {externalFooterLinks.map(item => (
-            <Box align="start">
-              <Link key={item.name} href={item.href} passHref>
+            <Box key={item.name} align="start">
+              <Link href={item.href} passHref>
                 <NavButton
                   item={item.name}
                   active={router.pathname === item.href}


### PR DESCRIPTION
Related: https://github.com/hpe-design/design-system/pull/642#discussion_r405813574

We were getting a console warning wanting a unique "key" prop for the Links in our Footer. This adds the key and fixes the warning.

Moving key up from Link to bounding Box.