### PR TITLE
Fix hpe icon size and update aruba color

### DIFF
--- a/aries-core/src/js/components/helpers/AppIdentity/AppIdentity.js
+++ b/aries-core/src/js/components/helpers/AppIdentity/AppIdentity.js
@@ -6,11 +6,11 @@ import { Aruba, Hpe } from 'grommet-icons';
 const brands = {
   hpe: {
     name: 'HPE',
-    logo: <Hpe color="brand" size="large" />,
+    logo: <Hpe color="brand" />,
   },
   aruba: {
     name: 'Aruba',
-    logo: <Aruba color="brand" />,
+    logo: <Aruba color="plain" />,
   },
 };
 

--- a/aries-site/src/examples/foundation/branding/ArubaIconExample.js
+++ b/aries-site/src/examples/foundation/branding/ArubaIconExample.js
@@ -7,7 +7,7 @@ export const ArubaIconExample = () => {
 
   return (
     <Box direction="row" align="center" gap="medium">
-      <Aruba color="orange!" size="30px" />
+      <Aruba color="plain" />
       <Box direction="row" gap="xsmall">
         <Text size={textSize} weight="bold">
           Aruba

--- a/aries-site/src/examples/foundation/branding/HpeElementExample.js
+++ b/aries-site/src/examples/foundation/branding/HpeElementExample.js
@@ -7,7 +7,7 @@ export const HpeElementExample = () => {
 
   return (
     <Box direction="row" align="center" gap="medium">
-      <Hpe color="brand" size="large" />
+      <Hpe color="brand" />
       <Box direction="row" gap="xsmall">
         <Text size={textSize} weight="bold">
           HPE

--- a/aries-site/src/examples/foundation/branding/HpeElementExample.js
+++ b/aries-site/src/examples/foundation/branding/HpeElementExample.js
@@ -7,7 +7,7 @@ export const HpeElementExample = () => {
 
   return (
     <Box direction="row" align="center" gap="medium">
-      <Hpe color="brand" size="66px" />
+      <Hpe color="brand" size="large" />
       <Box direction="row" gap="xsmall">
         <Text size={textSize} weight="bold">
           HPE


### PR DESCRIPTION
- The HPE brand icon was too big (Eric and I had changed some calculations a month or so ago to that HPE icon wouldn’t need extra sizing to match the default sizes of other icons, but I never stripped that out of the AppIdentity)
-  The aruba icon wasn’t using aruba orange either. Need to use color="plain" to allow built-in orange color to be used.