### PR TITLE
Leverage developer copy for carte site

### DIFF
--- a/aries-site/src/data/structure.js
+++ b/aries-site/src/data/structure.js
@@ -736,7 +736,7 @@ export const structure = [
       'Preferred environment',
       'ReactJS and Grommet starter resources',
       'Applying the HPE theme',
-      "What is our team doesn't use ReactJS?",
+      "What if our team doesn't use ReactJS?",
     ],
     relatedContent: ['Components', 'Templates', 'Designer'],
   },

--- a/aries-site/src/data/structure.js
+++ b/aries-site/src/data/structure.js
@@ -65,6 +65,15 @@ export const structure = [
     description:
       'Jumpstart application design and development with use-case specific templates. Interactive templates demonstrate desired user experiences and the building block components used to create them.',
     icon: (size, color) => <IconDiamond size={size} color={color} />,
+    preview: {
+      image: {
+        src: {
+          light: '/carte-templates-light.svg',
+          dark: '/carte-templates-dark.svg',
+        },
+        alt: 'HPE Cards Preview',
+      },
+    },
     seoDescription:
       'HPE Design System starter templates for jumpstarting application screen design and development.',
     pages: ['Cards', 'Dashboards', 'Forms', 'Lists'],
@@ -75,6 +84,15 @@ export const structure = [
     description:
       'Our component library provides a vetted set interface elements for use in your applications and websites. Using the latest web technology to keep you compliant and performant.',
     icon: (size, color) => <IconSquare size={size} color={color} />,
+    preview: {
+      image: {
+        src: {
+          light: '/carte-components-light.svg',
+          dark: '/carte-components-dark.svg',
+        },
+        alt: 'HPE Cards Preview',
+      },
+    },
     seoDescription:
       'Browse our component library of user interface elements for use in your applications and websites.',
     pages: [
@@ -113,6 +131,7 @@ export const structure = [
       'API Chomp',
       'Table Topper',
       'HPE Docs',
+      'Developer Guidance',
       'HPE Audience',
       'HPE Images',
     ],
@@ -705,5 +724,20 @@ export const structure = [
     seoDescription:
       'What and how we layout content is crucial to clear communication and ease-of-use.',
     sections: [],
+  },
+  {
+    name: 'Developer Guidance',
+    description:
+      'Resources for setting up your application with the HPE Design System library and HPE theme.',
+    seoDescription:
+      'Resources for setting up your application with the HPE Design System library and HPE theme.',
+    sections: [
+      'Getting started',
+      'Preferred environment',
+      'ReactJS and Grommet starter resources',
+      'Applying the HPE theme',
+      "What is our team doesn't use ReactJS?",
+    ],
+    relatedContent: ['Components', 'Templates', 'Designer'],
   },
 ];

--- a/aries-site/src/pages/extend/developer-guidance.js
+++ b/aries-site/src/pages/extend/developer-guidance.js
@@ -86,7 +86,7 @@ const DeveloperGuidance = () => {
               target="_blank"
               rel="noopener noreferrer"
             >
-              <code>grommet-theme-hpe</code>
+              grommet-theme-hpe
             </Anchor>{' '}
             theme via <code>npm</code> or <code>yarn</code>. This will help
             ensure that your application is aligned with the HPE Design System

--- a/aries-site/src/pages/extend/developer-guidance.js
+++ b/aries-site/src/pages/extend/developer-guidance.js
@@ -1,0 +1,128 @@
+import React from 'react';
+import { Anchor } from 'grommet';
+import { CardGrid, Meta, SubsectionText } from '../../components';
+import { ContentSection, Layout, Subsection } from '../../layouts';
+import { getPageDetails, getRelatedContent } from '../../utils';
+
+const title = 'Developer Guidance';
+const topic = 'Extend';
+const pageDetails = getPageDetails(title);
+const relatedContent = getRelatedContent(title);
+const DeveloperGuidance = () => {
+  return (
+    <Layout title={title}>
+      <Meta
+        title={title}
+        description={pageDetails.seoDescription}
+        canonicalUrl="https://design-system.hpe.design/extend/developer-guidance"
+      />
+      <ContentSection>
+        <Subsection name={title} level={1} topic={topic}>
+          <SubsectionText>{pageDetails.description}</SubsectionText>
+        </Subsection>
+        <Subsection name="Getting started">
+          <SubsectionText>
+            We're excited you're using the HPE Design System! Below are a set of
+            resources that will help you get your application set-up with
+            Grommet and the HPE theme. If you don't find what you're looking
+            for, please reach out in the #hpe-design-system channel on{' '}
+            <Anchor
+              label="Slack"
+              href="https://grommet.slack.com"
+              target="_blank"
+              rel="noopener noreferrer"
+            />
+            .
+          </SubsectionText>
+        </Subsection>
+        <Subsection name="Preferred environment" level={3}>
+          <SubsectionText>
+            The HPE Design System is primarily focused on user interfaces
+            developed with ReactJS and Grommet. We encourage teams to use
+            ReactJS and Grommet if possible because there are more resources,
+            examples, and community help for this environment.
+          </SubsectionText>
+          <SubsectionText>
+            Questions and feedback should be routed through the
+            #hpe-design-system channel on{' '}
+            <Anchor
+              label="Slack"
+              href="https://grommet.slack.com"
+              target="_blank"
+              rel="noopener noreferrer"
+            />
+            .
+          </SubsectionText>
+        </Subsection>
+        <Subsection name="ReactJS and Grommet starter resources" level={3}>
+          <SubsectionText>
+            If you are new to ReactJS, the{' '}
+            <Anchor
+              label="React Tutorial"
+              href="https://reactjs.org/tutorial/tutorial.html"
+              target="_blank"
+              rel="noopener noreferrer"
+            />{' '}
+            is a good place to start.
+          </SubsectionText>
+          <SubsectionText>
+            If you are already familiar with ReactJS but are unfamiliar with
+            Grommet, check out the{' '}
+            <Anchor
+              label="Getting Started with Grommet"
+              href="https://v2.grommet.io/starter"
+              target="_blank"
+              rel="noopener noreferrer"
+            />{' '}
+            guide.
+          </SubsectionText>
+        </Subsection>
+        <Subsection name="Applying the HPE theme" level={3}>
+          <SubsectionText>
+            Once your project is set up with ReactJS and Grommet, make sure you
+            have the latest{' '}
+            <Anchor
+              href="https://github.com/grommet/grommet-theme-hpe"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              <code>grommet-theme-hpe</code>
+            </Anchor>{' '}
+            theme via <code>npm</code> or <code>yarn</code>. This will help
+            ensure that your application is aligned with the HPE Design System
+            colors, fonts, and default component styles.
+          </SubsectionText>
+        </Subsection>
+        <Subsection name="What if our team doesn't use ReactJS?" level={3}>
+          <SubsectionText>
+            For non-ReactJS environments, such as those with a large code base
+            that are not ready to absorb changing the UI framework, we recommend
+            using the examples and patterns shown in the HPE Design System as a
+            reference. Styles should be matched as closely as possible. Using
+            the browser develop tools to inspect the styling can help with this
+            process.
+          </SubsectionText>
+          <SubsectionText>
+            If you have questions or would like some guidance on migrating to
+            ReactJS, please reach out to the{' '}
+            <Anchor
+              label="HPE Design System team"
+              href="mailto:hpedesignsystem@hpe.com"
+            />
+            .
+          </SubsectionText>
+        </Subsection>
+        {relatedContent.length > 0 ? (
+          <Subsection name="Related">
+            <SubsectionText>
+              Related content you may find useful when using {title}.
+            </SubsectionText>
+            <CardGrid cards={relatedContent} />
+          </Subsection>
+        ) : null}
+      </ContentSection>
+    </Layout>
+  );
+};
+
+export default DeveloperGuidance;


### PR DESCRIPTION
Preview: https://deploy-preview-708--keen-mayer-a86c8b.netlify.app/extend/developer-guidance
Leverages the previously posted developer copy for the new carte design and places this card under the Extend section

It'd be nice to be able to order the cards and have this one at the top.

Closes #663 