### PR TITLE
Add in designer guidance

### DIFF
--- a/aries-site/src/data/structure.js
+++ b/aries-site/src/data/structure.js
@@ -65,6 +65,15 @@ export const structure = [
     description:
       'Jumpstart application design and development with use-case specific templates. Interactive templates demonstrate desired user experiences and the building block components used to create them.',
     icon: (size, color) => <IconDiamond size={size} color={color} />,
+    preview: {
+      image: {
+        src: {
+          light: '/carte-templates-light.svg',
+          dark: '/carte-templates-dark.svg',
+        },
+        alt: 'HPE Cards Preview',
+      },
+    },
     seoDescription:
       'HPE Design System starter templates for jumpstarting application screen design and development.',
     pages: ['Cards', 'Dashboards', 'Forms', 'Lists'],
@@ -75,6 +84,15 @@ export const structure = [
     description:
       'Our component library provides a vetted set interface elements for use in your applications and websites. Using the latest web technology to keep you compliant and performant.',
     icon: (size, color) => <IconSquare size={size} color={color} />,
+    preview: {
+      image: {
+        src: {
+          light: '/carte-components-light.svg',
+          dark: '/carte-components-dark.svg',
+        },
+        alt: 'HPE Cards Preview',
+      },
+    },
     seoDescription:
       'Browse our component library of user interface elements for use in your applications and websites.',
     pages: [

--- a/aries-site/src/data/structure.js
+++ b/aries-site/src/data/structure.js
@@ -108,6 +108,7 @@ export const structure = [
     seoDescription:
       'All the aesthetics, best practices, and information about the platform and how to wield it.',
     pages: [
+      'Designer Guidance',
       'Global Sidebar',
       'Designer',
       'API Chomp',
@@ -705,5 +706,19 @@ export const structure = [
     seoDescription:
       'What and how we layout content is crucial to clear communication and ease-of-use.',
     sections: [],
+  },
+  {
+    name: 'Designer Guidance',
+    description:
+      'Starter files, patterns, interactions, and workflows on how to succeed using the design resources from HPE Design System and the HPE Brand.',
+    seoDescription:
+      'View patterns, interactions, and other best practices for how to succeed using resources included with the HPE Design System.',
+    sections: [
+      'Getting started',
+      'Setting up your Figma account',
+      'Joining the HPE Design System Figma team',
+      'HPE Design System Library',
+    ],
+    relatedContent: ['Components', 'Templates', 'Designer'],
   },
 ];

--- a/aries-site/src/pages/extend/designer-guidance.js
+++ b/aries-site/src/pages/extend/designer-guidance.js
@@ -48,8 +48,14 @@ const DesignerGuidance = () => {
             page is a good place to start.
           </SubsectionText>
           <SubsectionText>
-            Create your account with your HPE email to be able to have access to
-            all of the HPE Design System files.
+            <Anchor
+              label="Create a Figma account"
+              href="https://help.figma.com/hc/en-us/articles/360039811114-Create-a-Figma-account"
+              target="_blank"
+              rel="noopener noreferrer"
+            />{' '}
+            with your HPE email address. Using your HPE email provides immediate 
+            access to all HPE Design System files.
           </SubsectionText>
           <SubsectionText>
             If you would prefer to access the HPE Design System library in a

--- a/aries-site/src/pages/extend/designer-guidance.js
+++ b/aries-site/src/pages/extend/designer-guidance.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Anchor } from 'grommet';
+import { Anchor, List } from 'grommet';
 import { CardGrid, Meta, SubsectionText } from '../../components';
 import { ContentSection, Layout, Subsection } from '../../layouts';
 import { getPageDetails, getRelatedContent } from '../../utils';
@@ -8,6 +8,7 @@ const title = 'Designer Guidance';
 const topic = 'Extend';
 const pageDetails = getPageDetails(title);
 const relatedContent = getRelatedContent(title);
+
 const DesignerGuidance = () => {
   return (
     <Layout title={title}>
@@ -65,19 +66,27 @@ const DesignerGuidance = () => {
         <Subsection name="Joining the HPE Design System Figma team" level={3}>
           <SubsectionText>
             Once you have made a Figma account with your HPE email, you can
-            request to join the HPE Design System team.
+            request to join the HPE Design System team. You can do so by
+            following these steps:
           </SubsectionText>
-          <SubsectionText>
-            1) Log into Figma and look for an HPE icon in your left control bar.
-            Navigate to this section, you will see all the HPE Figma teams. Look
-            for "HPE Design System" and click "Request to join".
-          </SubsectionText>
-          <SubsectionText>
-            2) Click on HPE. Here, you will see all HPE Figma teams.
-          </SubsectionText>
-          <SubsectionText>
-            3) Look for "HPE Design System" and click "Request to join".
-          </SubsectionText>
+          <List
+            as="ol"
+            data={[
+              `Log into Figma and look for an HPE icon in your left control bar.
+              Navigate to this section, you will see all the HPE Figma teams. 
+              Look for "HPE Design System" and click "Request to join".`,
+              'Click on HPE. Here, you will see all HPE Figma teams.',
+              'Look for "HPE Design System" and click "Request to join".',
+            ]}
+            border={{ style: 'hidden' }}
+            pad={{ vertical: 'xsmall' }}
+          >
+            {(item, index) => (
+              <SubsectionText key={item} size="medium">
+                {index + 1}) {item}
+              </SubsectionText>
+            )}
+          </List>
           <SubsectionText>
             Once you have been added to this team, you will have access to all
             of the HPE Design System files.

--- a/aries-site/src/pages/extend/designer-guidance.js
+++ b/aries-site/src/pages/extend/designer-guidance.js
@@ -1,0 +1,130 @@
+import React from 'react';
+import { Anchor } from 'grommet';
+import { CardGrid, Meta, SubsectionText } from '../../components';
+import { ContentSection, Layout, Subsection } from '../../layouts';
+import { getPageDetails, getRelatedContent } from '../../utils';
+
+const title = 'Designer Guidance';
+const topic = 'Extend';
+const pageDetails = getPageDetails(title);
+const relatedContent = getRelatedContent(title);
+const DesignerGuidance = () => {
+  return (
+    <Layout title={title}>
+      <Meta
+        title={title}
+        description={pageDetails.seoDescription}
+        canonicalUrl="https://design-system.hpe.design/extend/designer-guidance"
+      />
+      <ContentSection>
+        <Subsection name={title} level={1} topic={topic}>
+          <SubsectionText>{pageDetails.description}</SubsectionText>
+        </Subsection>
+        <Subsection name="Getting started">
+          <SubsectionText>
+            We're excited you're using the HPE Design System! Below are a set of
+            resources that will help you get started using the HPE Design System
+            components in your designs. If you don't find what you're looking
+            for, please reach out in the #hpe-design-system channel on{' '}
+            <Anchor
+              label="Slack"
+              href="https://grommet.slack.com"
+              target="_blank"
+              rel="noopener noreferrer"
+            />
+            .
+          </SubsectionText>
+        </Subsection>
+        <Subsection name="Setting up your Figma account" level={3}>
+          <SubsectionText>
+            If you are new to Figma, the{' '}
+            <Anchor
+              label="Figma Getting Started"
+              href="https://help.figma.com/hc/en-us/categories/360002051613-Getting-Started"
+              target="_blank"
+              rel="noopener noreferrer"
+            />{' '}
+            page is a good place to start.
+          </SubsectionText>
+          <SubsectionText>
+            Create your account with your HPE email to be able to have access to
+            all of the HPE Design System files.
+          </SubsectionText>
+          <SubsectionText>
+            If you would prefer to access the HPE Design System library in a
+            desktop app, you can download the{' '}
+            <Anchor
+              label="Figma Desktop App"
+              href="https://help.figma.com/hc/en-us/articles/360039823654-Download-the-Figma-Desktop-App#Download_the_Desktop_App"
+              target="_blank"
+              rel="noopener noreferrer"
+            />{' '}
+            for MacOS or Windows.
+          </SubsectionText>
+        </Subsection>
+        <Subsection name="Joining the HPE Design System Figma team" level={3}>
+          <SubsectionText>
+            Once you have made a Figma account with your HPE email, you can
+            request to join the HPE Design System team.
+          </SubsectionText>
+          <SubsectionText>
+            1) Log into Figma and look for an HPE icon in your left control bar.
+            Navigate to this section, you will see all the HPE Figma teams. Look
+            for "HPE Design System" and click "Request to join".
+          </SubsectionText>
+          <SubsectionText>
+            2) Click on HPE. Here, you will see all HPE Figma teams.
+          </SubsectionText>
+          <SubsectionText>
+            3) Look for "HPE Design System" and click "Request to join".
+          </SubsectionText>
+          <SubsectionText>
+            Once you have been added to this team, you will have access to all
+            of the HPE Design System files.
+          </SubsectionText>
+        </Subsection>
+        <Subsection name="HPE Design System Library" level={3}>
+          <SubsectionText>
+            The{' '}
+            <Anchor
+              label="HPE Design System sticker sheet"
+              href="https://www.figma.com/file/ItdN5pNBubFpV8GP5RowY3/HPE-Component-Sticker-Sheet?node-id=58%3A40"
+              target="_blank"
+              rel="noopener noreferrer"
+            />{' '}
+            provides a foundation for designing HPE applications. The sticker
+            sheet provides an overview of the components contained within the
+            Design System library.
+          </SubsectionText>
+          <SubsectionText>
+            To access individual files for each component, navigate to the HPE
+            Design System Figma team. If you are having trouble accessing the
+            files, you may need to{' '}
+            <Anchor
+              label="join the HPE Design System Figma team"
+              href="#joining-the-hpe-design-system-figma-team"
+            />
+            .
+          </SubsectionText>
+          <SubsectionText>
+            Each component has its own library file that demonstrates the
+            various states of the component such as enabled, disabled, hover,
+            active, and focus. The examples within these files can be leveraged
+            within your design files and are built to be interactive and
+            responsive.
+          </SubsectionText>
+        </Subsection>
+        {relatedContent.length > 0 ? (
+          <Subsection name="Related">
+            <SubsectionText>
+              Related content you may find useful when using {title}.
+            </SubsectionText>
+            <CardGrid cards={relatedContent} />
+          </Subsection>
+        ) : null}
+      </ContentSection>
+    </Layout>
+  );
+};
+
+export default DesignerGuidance;

--- a/aries-site/src/pages/extend/designer-guidance.js
+++ b/aries-site/src/pages/extend/designer-guidance.js
@@ -54,7 +54,7 @@ const DesignerGuidance = () => {
               target="_blank"
               rel="noopener noreferrer"
             />{' '}
-            with your HPE email address. Using your HPE email provides immediate 
+            with your HPE email address. Using your HPE email provides immediate
             access to all HPE Design System files.
           </SubsectionText>
           <SubsectionText>


### PR DESCRIPTION
Preview: https://deploy-preview-709--keen-mayer-a86c8b.netlify.app/extend/designer-guidance
Leverages the previously posted designer copy for the new carte design and places this card under the Extend section

It'd be nice to be able to order the cards and have this one at the top.

Closes #705 