### PR TITLE
remove extra boxes

### DIFF
--- a/aries-site/src/examples/components/menu/MenuExample.js
+++ b/aries-site/src/examples/components/menu/MenuExample.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Box, Menu } from 'grommet';
+import { Menu } from 'grommet';
 
 export const MenuExample = () => {
   const items = [
@@ -9,8 +9,6 @@ export const MenuExample = () => {
   ];
 
   return (
-    <Box round="xsmall">
       <Menu label="Manage Account" items={items} width="medium" />
-    </Box>
   );
 };

--- a/aries-site/src/examples/components/search/SearchExample.js
+++ b/aries-site/src/examples/components/search/SearchExample.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import styled from 'styled-components';
-import { TextInput, Box } from 'grommet';
+import { TextInput } from 'grommet';
 import { Search as SearchIcon } from 'grommet-icons';
 
 // Inputs should always be accompanied by labels for accessibility. An icon
@@ -16,14 +16,12 @@ export const SearchExample = () => {
   const [value, setValue] = React.useState();
 
   return (
-    <Box width="medium">
-      <StyledTextInput
-        icon={<SearchIcon id="search-icon" />}
-        placeholder="Search placeholder"
-        reverse
-        value={value}
-        onChange={event => setValue(event.target.value)}
-      />
-    </Box>
+    <StyledTextInput
+      icon={<SearchIcon id="search-icon" />}
+      placeholder="Search placeholder"
+      reverse
+      value={value}
+      onChange={event => setValue(event.target.value)}
+    />
   );
 };

--- a/aries-site/src/examples/components/search/SearchIconPositionExample.js
+++ b/aries-site/src/examples/components/search/SearchIconPositionExample.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import styled from 'styled-components';
-import { TextInput, Box } from 'grommet';
+import { TextInput } from 'grommet';
 import { Search as SearchIcon } from 'grommet-icons';
 
 // Inputs should always be accompanied by labels for accessibility. An icon
@@ -16,13 +16,11 @@ export const SearchIconPositionExample = () => {
   const [value, setValue] = React.useState();
 
   return (
-    <Box width="medium">
-      <StyledTextInput
-        icon={<SearchIcon id="search-icon" />}
-        placeholder="Search placeholder"
-        value={value}
-        onChange={event => setValue(event.target.value)}
-      />
-    </Box>
+    <StyledTextInput
+      icon={<SearchIcon id="search-icon" />}
+      placeholder="Search placeholder"
+      value={value}
+      onChange={event => setValue(event.target.value)}
+    />
   );
 };

--- a/aries-site/src/examples/components/search/SearchSuggestionsExample.js
+++ b/aries-site/src/examples/components/search/SearchSuggestionsExample.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import styled from 'styled-components';
-import { Box, TextInput } from 'grommet';
+import { TextInput } from 'grommet';
 import { Search as SearchIcon } from 'grommet-icons';
 
 // Inputs should always be accompanied by labels for accessibility. An icon
@@ -87,7 +87,6 @@ export const SearchSuggestionsExample = () => {
   };
 
   return (
-    <Box width="medium">
       <StyledTextInput
         icon={<SearchIcon id="search-icon" />}
         placeholder="Search placeholder"
@@ -96,6 +95,5 @@ export const SearchSuggestionsExample = () => {
         value={value}
         onChange={onChange}
       />
-    </Box>
   );
 };

--- a/aries-site/src/examples/components/select/SelectDisabledExample.js
+++ b/aries-site/src/examples/components/select/SelectDisabledExample.js
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { Box, CheckBox, FormField, Select } from 'grommet';
+import { Box, CheckBox, Form, FormField, Select } from 'grommet';
 
 const options = [
   'Item One',
@@ -16,41 +16,45 @@ export const SelectDisabledExample = () => {
 
   return (
     <Box width="medium">
-      <FormField
-        htmlFor="disabled-example__input"
-        name="disabled-example"
-        label="Label"
-        /* Note: The `disabled` property should be set on both 
-        the FormField as well as the Select component */
-        disabled={disabled}
-      >
-        <Select
-          id="disabled-example"
+      <Form>
+        <FormField
+          htmlFor="disabled-example__input"
           name="disabled-example"
-          placeholder="Select item"
-          options={options}
-          value={selected}
-          onChange={({ option }) => setSelected(option)}
+          label="Label"
           /* Note: The `disabled` property should be set on both 
-          the FormField as well as the Select component */
+        the FormField as well as the Select component */
           disabled={disabled}
-        />
-      </FormField>
-      <FormField
-        htmlFor="disabledToggle"
-        name="disabledToggle"
-        help="Set the disabled state for the Select input above."
-      >
-        <CheckBox
-          toggle
-          id="disabledToggle"
+        >
+          <Select
+            id="disabled-example"
+            name="disabled-example"
+            placeholder="Select item"
+            options={options}
+            value={selected}
+            onChange={({ option }) => setSelected(option)}
+            /* Note: The `disabled` property should be set on both 
+          the FormField as well as the Select component */
+            disabled={disabled}
+          />
+        </FormField>
+      </Form>
+      <Form>
+        <FormField
+          htmlFor="disabledToggle"
           name="disabledToggle"
-          label={disabled ? 'Disabled' : 'Enabled'}
-          checked={!disabled}
-          onChange={() => setDisabled(!disabled)}
-          direction="row"
-        />
-      </FormField>
+          help="Set the disabled state for the Select input above."
+        >
+          <CheckBox
+            toggle
+            id="disabledToggle"
+            name="disabledToggle"
+            label={disabled ? 'Disabled' : 'Enabled'}
+            checked={!disabled}
+            onChange={() => setDisabled(!disabled)}
+            direction="row"
+          />
+        </FormField>
+      </Form>
     </Box>
   );
 };

--- a/aries-site/src/examples/components/select/SelectExample.js
+++ b/aries-site/src/examples/components/select/SelectExample.js
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { Box, FormField, Select } from 'grommet';
+import { FormField, Select } from 'grommet';
 
 const options = [
   'Item One',
@@ -14,7 +14,6 @@ export const SelectExample = () => {
   const [selected, setSelected] = useState('');
 
   return (
-    <Box width="medium">
       <FormField
         htmlFor="select-example__input"
         name="select-example"
@@ -29,6 +28,5 @@ export const SelectExample = () => {
           onChange={({ option }) => setSelected(option)}
         />
       </FormField>
-    </Box>
   );
 };

--- a/aries-site/src/examples/components/select/SelectExample.js
+++ b/aries-site/src/examples/components/select/SelectExample.js
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { FormField, Select } from 'grommet';
+import { Form, FormField, Select } from 'grommet';
 
 const options = [
   'Item One',
@@ -14,6 +14,7 @@ export const SelectExample = () => {
   const [selected, setSelected] = useState('');
 
   return (
+    <Form>
       <FormField
         htmlFor="select-example__input"
         name="select-example"
@@ -28,5 +29,6 @@ export const SelectExample = () => {
           onChange={({ option }) => setSelected(option)}
         />
       </FormField>
+    </Form>
   );
 };

--- a/aries-site/src/examples/components/select/SelectMultipleExample.js
+++ b/aries-site/src/examples/components/select/SelectMultipleExample.js
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { Box, Form, FormField, Select } from 'grommet';
+import { Form, FormField, Select } from 'grommet';
 
 const options = ['Item One', 'Item Two', 'Item Three', 'Item Four'];
 
@@ -7,24 +7,22 @@ export const SelectMultipleExample = () => {
   const [selected, setSelected] = useState('');
 
   return (
-    <Box width="medium">
-      <Form>
-        <FormField
-          htmlFor="multi-select-example__input"
+    <Form>
+      <FormField
+        htmlFor="multi-select-example__input"
+        name="multi-select-example"
+        label="Label for Multi-Select"
+      >
+        <Select
+          id="multi-select-example"
           name="multi-select-example"
-          label="Label for Multi-Select"
-        >
-          <Select
-            id="multi-select-example"
-            name="multi-select-example"
-            placeholder="Select multiple items"
-            options={options}
-            value={selected}
-            onChange={({ value: nextValue }) => setSelected(nextValue)}
-            multiple
-          />
-        </FormField>
-      </Form>
-    </Box>
+          placeholder="Select multiple items"
+          options={options}
+          value={selected}
+          onChange={({ value: nextValue }) => setSelected(nextValue)}
+          multiple
+        />
+      </FormField>
+    </Form>
   );
 };

--- a/aries-site/src/examples/components/select/SelectMultipleExample.js
+++ b/aries-site/src/examples/components/select/SelectMultipleExample.js
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { Box, FormField, Select } from 'grommet';
+import { Box, Form, FormField, Select } from 'grommet';
 
 const options = ['Item One', 'Item Two', 'Item Three', 'Item Four'];
 
@@ -8,21 +8,23 @@ export const SelectMultipleExample = () => {
 
   return (
     <Box width="medium">
-      <FormField
-        htmlFor="multi-select-example__input"
-        name="multi-select-example"
-        label="Label for Multi-Select"
-      >
-        <Select
-          id="multi-select-example"
+      <Form>
+        <FormField
+          htmlFor="multi-select-example__input"
           name="multi-select-example"
-          placeholder="Select multiple items"
-          options={options}
-          value={selected}
-          onChange={({ value: nextValue }) => setSelected(nextValue)}
-          multiple
-        />
-      </FormField>
+          label="Label for Multi-Select"
+        >
+          <Select
+            id="multi-select-example"
+            name="multi-select-example"
+            placeholder="Select multiple items"
+            options={options}
+            value={selected}
+            onChange={({ value: nextValue }) => setSelected(nextValue)}
+            multiple
+          />
+        </FormField>
+      </Form>
     </Box>
   );
 };

--- a/aries-site/src/examples/components/select/SelectSearchExample.js
+++ b/aries-site/src/examples/components/select/SelectSearchExample.js
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { Box, Form, FormField, Select } from 'grommet';
+import { Form, FormField, Select } from 'grommet';
 
 const defaultOptions = ['EMEA', 'Asia/Pacific', 'Americas', 'Polar Regions'];
 
@@ -21,7 +21,6 @@ export const SelectSearchExample = () => {
   };
 
   return (
-    <Box width="medium">
       <Form>
         <FormField
           htmlFor="select-with-search__input"
@@ -41,6 +40,5 @@ export const SelectSearchExample = () => {
           />
         </FormField>
       </Form>
-    </Box>
   );
 };

--- a/aries-site/src/examples/components/select/SelectSearchExample.js
+++ b/aries-site/src/examples/components/select/SelectSearchExample.js
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { Box, FormField, Select } from 'grommet';
+import { Box, Form, FormField, Select } from 'grommet';
 
 const defaultOptions = ['EMEA', 'Asia/Pacific', 'Americas', 'Polar Regions'];
 
@@ -22,23 +22,25 @@ export const SelectSearchExample = () => {
 
   return (
     <Box width="medium">
-      <FormField
-        htmlFor="select-with-search__input"
-        name="select-with-search"
-        label="Location"
-        help="Type to filter the location options"
-      >
-        <Select
-          id="select-with-search"
+      <Form>
+        <FormField
+          htmlFor="select-with-search__input"
           name="select-with-search"
-          placeholder="Select location"
-          searchPlaceholder="Search locations"
-          options={options}
-          value={selected}
-          onChange={({ option }) => setSelected(option)}
-          onSearch={text => onSearch(text)}
-        />
-      </FormField>
+          label="Location"
+          help="Type to filter the location options"
+        >
+          <Select
+            id="select-with-search"
+            name="select-with-search"
+            placeholder="Select location"
+            searchPlaceholder="Search locations"
+            options={options}
+            value={selected}
+            onChange={({ option }) => setSelected(option)}
+            onSearch={text => onSearch(text)}
+          />
+        </FormField>
+      </Form>
     </Box>
   );
 };

--- a/aries-site/src/examples/components/select/SelectValidationExample.js
+++ b/aries-site/src/examples/components/select/SelectValidationExample.js
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { Box, Form, FormField, Select } from 'grommet';
+import { Form, FormField, Select } from 'grommet';
 
 const options = [
   'Item One',
@@ -17,29 +17,27 @@ export const SelectValidationExample = () => {
   );
 
   return (
-    <Box width="medium">
-      <Form>
-        <FormField
-          htmlFor="validation-example__input"
+    <Form>
+      <FormField
+        htmlFor="validation-example__input"
+        name="validation-example"
+        label="Label"
+        error={message}
+      >
+        <Select
+          id="validation-example"
           name="validation-example"
-          label="Label"
-          error={message}
-        >
-          <Select
-            id="validation-example"
-            name="validation-example"
-            placeholder="Select item"
-            options={options}
-            value={selected}
-            onChange={({ option }) => {
-              setSelected(option);
-              if (option) {
-                setMessage();
-              }
-            }}
-          />
-        </FormField>
-      </Form>
-    </Box>
+          placeholder="Select item"
+          options={options}
+          value={selected}
+          onChange={({ option }) => {
+            setSelected(option);
+            if (option) {
+              setMessage();
+            }
+          }}
+        />
+      </FormField>
+    </Form>
   );
 };

--- a/aries-site/src/examples/components/tabs/TabStatesExample.js
+++ b/aries-site/src/examples/components/tabs/TabStatesExample.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Box, Tab, Tabs, Text } from 'grommet';
+import { Box, Tab, Tabs } from 'grommet';
 
 export const TabStatesExample = () => {
   const [index, setIndex] = React.useState(0);
@@ -9,9 +9,7 @@ export const TabStatesExample = () => {
     <Box>
       <Tabs activeIndex={index} onActive={onActive} justify="start">
         <Tab title={index === 0 ? 'Active' : 'Enabled'}>
-          <Box margin="small">
-            <Text>The first tab is active.</Text>
-          </Box>
+          <Box margin="small">The first tab is active.</Box>
         </Tab>
         <Tab title={index === 1 ? 'Active' : 'Enabled'}>
           <Box margin="small">The second tab is active.</Box>

--- a/aries-site/src/examples/components/tabs/TabWithIconExample.js
+++ b/aries-site/src/examples/components/tabs/TabWithIconExample.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Box, Tab, Tabs, Text } from 'grommet';
+import { Box, Tab, Tabs } from 'grommet';
 import { Currency, Home, Notification, User } from 'grommet-icons';
 
 export const TabWithIconExample = () => {
@@ -10,9 +10,7 @@ export const TabWithIconExample = () => {
     <Box>
       <Tabs activeIndex={index} onActive={onActive} justify="start">
         <Tab title="General" icon={<Home />}>
-          <Box margin="small">
-            <Text>General Information</Text>
-          </Box>
+          <Box margin="small">General Information</Box>
         </Tab>
         <Tab title="Account" icon={<User />}>
           <Box margin="small">Account Information</Box>

--- a/aries-site/src/examples/components/textarea/TextAreaDisabledExample.js
+++ b/aries-site/src/examples/components/textarea/TextAreaDisabledExample.js
@@ -4,18 +4,22 @@ import { Box, FormField, TextArea } from 'grommet';
 export const TextAreaDisabledExample = () => {
   return (
     <Box width="medium">
-      <FormField
-        label="Additional feedback"
-        htmlFor="text-area-disabled-example"
-        disabled
-      >
-        <TextArea
-          id="text-area-disabled-example"
-          placeholder="Placeholder text"
-          resize="vertical"
+      <Form>
+        <FormField
+          label="Additional feedback"
+          htmlFor="text-area-disabled-example"
+          name="disabled-example"
           disabled
-        />
-      </FormField>
+        >
+          <TextArea
+            name="disabled-example"
+            id="text-area-disabled-example"
+            placeholder="Placeholder text"
+            resize="vertical"
+            disabled
+          />
+        </FormField>
+      </Form>
     </Box>
   );
 };

--- a/aries-site/src/examples/components/textarea/TextAreaDisabledExample.js
+++ b/aries-site/src/examples/components/textarea/TextAreaDisabledExample.js
@@ -1,9 +1,8 @@
 import React from 'react';
-import { Box, FormField, TextArea } from 'grommet';
+import { Form, FormField, TextArea } from 'grommet';
 
 export const TextAreaDisabledExample = () => {
   return (
-    <Box width="medium">
       <Form>
         <FormField
           label="Additional feedback"
@@ -20,6 +19,5 @@ export const TextAreaDisabledExample = () => {
           />
         </FormField>
       </Form>
-    </Box>
   );
 };

--- a/aries-site/src/examples/components/textarea/TextAreaExample.js
+++ b/aries-site/src/examples/components/textarea/TextAreaExample.js
@@ -1,9 +1,8 @@
 import React from 'react';
-import { Box, FormField, TextArea } from 'grommet';
+import { Form, FormField, TextArea } from 'grommet';
 
 export const TextAreaExample = () => {
   return (
-    <Box width="medium">
       <Form>
         <FormField
           name="textArea-example"
@@ -18,6 +17,5 @@ export const TextAreaExample = () => {
           />
         </FormField>
       </Form>
-    </Box>
   );
 };

--- a/aries-site/src/examples/components/textarea/TextAreaExample.js
+++ b/aries-site/src/examples/components/textarea/TextAreaExample.js
@@ -4,13 +4,20 @@ import { Box, FormField, TextArea } from 'grommet';
 export const TextAreaExample = () => {
   return (
     <Box width="medium">
-      <FormField label="Additional feedback" htmlFor="text-area-example">
-        <TextArea
-          id="text-area-example"
-          placeholder="i.e. ideas, inspirations, or concerns"
-          resize="vertical"
-        />
-      </FormField>
+      <Form>
+        <FormField
+          name="textArea-example"
+          label="Additional feedback"
+          htmlFor="text-area-example"
+        >
+          <TextArea
+            name="textArea-example"
+            id="text-area-example"
+            placeholder="i.e. ideas, inspirations, or concerns"
+            resize="vertical"
+          />
+        </FormField>
+      </Form>
     </Box>
   );
 };

--- a/aries-site/src/examples/components/textarea/TextAreaValidationExample.js
+++ b/aries-site/src/examples/components/textarea/TextAreaValidationExample.js
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { Box, Form, FormField, TextArea } from 'grommet';
+import { Form, FormField, TextArea } from 'grommet';
 
 export const TextAreaValidationExample = () => {
   const [value, setValue] = useState('');
@@ -7,8 +7,6 @@ export const TextAreaValidationExample = () => {
   const [message, setMessage] = useState(defaultErrorMessage);
 
   return (
-    <Box>
-      <Box width="small">
         <Form>
           <FormField
             name="required-field"
@@ -32,7 +30,5 @@ export const TextAreaValidationExample = () => {
             />
           </FormField>
         </Form>
-      </Box>
-    </Box>
   );
 };

--- a/aries-site/src/examples/components/textarea/TextAreaValidationExample.js
+++ b/aries-site/src/examples/components/textarea/TextAreaValidationExample.js
@@ -7,28 +7,28 @@ export const TextAreaValidationExample = () => {
   const [message, setMessage] = useState(defaultErrorMessage);
 
   return (
-        <Form>
-          <FormField
-            name="required-field"
-            label="Label"
-            htmlFor="required-field"
-            error={message}
-          >
-            <TextArea
-              name="required-field"
-              id="required-field"
-              placeholder="Placeholder text"
-              onChange={event => {
-                if (event.target.value.length > 0) {
-                  setMessage('');
-                } else {
-                  setMessage(defaultErrorMessage);
-                }
-                setValue(event.target.value);
-              }}
-              value={value}
-            />
-          </FormField>
-        </Form>
+    <Form>
+      <FormField
+        name="required-field"
+        label="Label"
+        htmlFor="required-field"
+        error={message}
+      >
+        <TextArea
+          name="required-field"
+          id="required-field"
+          placeholder="Placeholder text"
+          onChange={event => {
+            if (event.target.value.length > 0) {
+              setMessage('');
+            } else {
+              setMessage(defaultErrorMessage);
+            }
+            setValue(event.target.value);
+          }}
+          value={value}
+        />
+      </FormField>
+    </Form>
   );
 };

--- a/aries-site/src/examples/components/textinput/TextInputDisabledExample.js
+++ b/aries-site/src/examples/components/textinput/TextInputDisabledExample.js
@@ -1,12 +1,20 @@
 import React from 'react';
-import { FormField, TextInput } from 'grommet';
+import { Form, FormField, TextInput } from 'grommet';
 
 export const TextInputDisabledExample = () => (
-      <FormField label="Label" htmlFor="disabled-input" disabled>
-        <TextInput
-          id="disabled-input"
-          placeholder="Placeholder text"
-          disabled
-        />
-      </FormField>
+  <Form>
+    <FormField
+      name="disabled-example"
+      label="Label"
+      htmlFor="disabled-input"
+      disabled
+    >
+      <TextInput
+        name="disabled-example"
+        id="disabled-input"
+        placeholder="Placeholder text"
+        disabled
+      />
+    </FormField>
+  </Form>
 );

--- a/aries-site/src/examples/components/textinput/TextInputDisabledExample.js
+++ b/aries-site/src/examples/components/textinput/TextInputDisabledExample.js
@@ -1,9 +1,7 @@
 import React from 'react';
-import { Box, FormField, TextInput } from 'grommet';
+import { FormField, TextInput } from 'grommet';
 
 export const TextInputDisabledExample = () => (
-  <Box>
-    <Box width="small">
       <FormField label="Label" htmlFor="disabled-input" disabled>
         <TextInput
           id="disabled-input"
@@ -11,6 +9,4 @@ export const TextInputDisabledExample = () => (
           disabled
         />
       </FormField>
-    </Box>
-  </Box>
 );

--- a/aries-site/src/examples/components/textinput/TextInputExample.js
+++ b/aries-site/src/examples/components/textinput/TextInputExample.js
@@ -1,12 +1,8 @@
 import React from 'react';
-import { Box, FormField, TextInput } from 'grommet';
+import { FormField, TextInput } from 'grommet';
 
 export const TextInputExample = () => (
-  <Box direction="row-responsive" gap="large" align="end">
-    <Box width="small">
-      <FormField label="Label" htmlFor="username">
-        <TextInput id="username" placeholder="Placeholder text" type="email" />
-      </FormField>
-    </Box>
-  </Box>
+  <FormField label="Label" htmlFor="username">
+    <TextInput id="username" placeholder="Placeholder text" type="email" />
+  </FormField>
 );

--- a/aries-site/src/examples/components/textinput/TextInputExample.js
+++ b/aries-site/src/examples/components/textinput/TextInputExample.js
@@ -1,8 +1,15 @@
 import React from 'react';
-import { FormField, TextInput } from 'grommet';
+import { Form, FormField, TextInput } from 'grommet';
 
 export const TextInputExample = () => (
-  <FormField label="Label" htmlFor="username">
-    <TextInput id="username" placeholder="Placeholder text" type="email" />
-  </FormField>
+  <Form>
+    <FormField name="textInput-example" label="Label" htmlFor="username">
+      <TextInput
+        name="textInput-example"
+        id="username"
+        placeholder="Placeholder text"
+        type="email"
+      />
+    </FormField>
+  </Form>
 );

--- a/aries-site/src/examples/components/textinput/TextInputLabeledByExample.js
+++ b/aries-site/src/examples/components/textinput/TextInputLabeledByExample.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import styled from 'styled-components';
-import { Box, TextInput } from 'grommet';
+import { TextInput } from 'grommet';
 import { Search } from 'grommet-icons';
 
 export const TextInputLabeledByExample = () => {
@@ -9,12 +9,10 @@ export const TextInputLabeledByExample = () => {
   }))``;
 
   return (
-    <Box width="medium">
       <StyledTextInput
         placeholder="Search..."
         icon={<Search id="search-icon" />}
         reverse
       />
-    </Box>
   );
 };

--- a/aries-site/src/examples/components/textinput/TextInputLabeledByExample.js
+++ b/aries-site/src/examples/components/textinput/TextInputLabeledByExample.js
@@ -9,14 +9,12 @@ export const TextInputLabeledByExample = () => {
   }))``;
 
   return (
-    <Box direction="row-responsive" gap="large" align="end">
-      <Box width="medium">
-        <StyledTextInput
-          placeholder="Search..."
-          icon={<Search id="search-icon" />}
-          reverse
-        />
-      </Box>
+    <Box width="medium">
+      <StyledTextInput
+        placeholder="Search..."
+        icon={<Search id="search-icon" />}
+        reverse
+      />
     </Box>
   );
 };

--- a/aries-site/src/examples/components/textinput/TextInputPasswordExample.js
+++ b/aries-site/src/examples/components/textinput/TextInputPasswordExample.js
@@ -1,18 +1,25 @@
 import React, { useState } from 'react';
-import { FormField, TextInput } from 'grommet';
+import { Form, FormField, TextInput } from 'grommet';
 
 export const TextInputPasswordExample = () => {
   const [password, setPassword] = useState('123password');
 
   return (
-    <FormField label="Password" htmlFor="password-example">
-      <TextInput
-        id="password-example"
-        placeholder="Placeholder text"
-        type="password"
-        value={password}
-        onChange={event => setPassword(event.target.value)}
-      />
-    </FormField>
+    <Form>
+      <FormField
+        name="password-example"
+        label="Password"
+        htmlFor="password-example"
+      >
+        <TextInput
+          id="password-example"
+          name="password-example"
+          placeholder="Placeholder text"
+          type="password"
+          value={password}
+          onChange={event => setPassword(event.target.value)}
+        />
+      </FormField>
+    </Form>
   );
 };

--- a/aries-site/src/examples/components/textinput/TextInputPasswordExample.js
+++ b/aries-site/src/examples/components/textinput/TextInputPasswordExample.js
@@ -1,22 +1,18 @@
 import React, { useState } from 'react';
-import { Box, FormField, TextInput } from 'grommet';
+import { FormField, TextInput } from 'grommet';
 
 export const TextInputPasswordExample = () => {
   const [password, setPassword] = useState('123password');
 
   return (
-    <Box direction="row-responsive" gap="large" align="end">
-      <Box width="small">
-        <FormField label="Password" htmlFor="password-example">
-          <TextInput
-            id="password-example"
-            placeholder="Placeholder text"
-            type="password"
-            value={password}
-            onChange={event => setPassword(event.target.value)}
-          />
-        </FormField>
-      </Box>
-    </Box>
+    <FormField label="Password" htmlFor="password-example">
+      <TextInput
+        id="password-example"
+        placeholder="Placeholder text"
+        type="password"
+        value={password}
+        onChange={event => setPassword(event.target.value)}
+      />
+    </FormField>
   );
 };

--- a/aries-site/src/examples/components/textinput/TextInputSuggestionsExample.js
+++ b/aries-site/src/examples/components/textinput/TextInputSuggestionsExample.js
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { Box, FormField, TextInput } from 'grommet';
+import { Box, Form, FormField, TextInput } from 'grommet';
 
 export const TextInputSuggestionsExample = () => {
   const allSuggestions = ['Apples', 'Oranges', 'Bananas'];
@@ -24,35 +24,43 @@ export const TextInputSuggestionsExample = () => {
   return (
     <Box direction="row-responsive" gap="large" align="end">
       <Box width="small">
-        <FormField
-          label="Static suggestions"
-          help={`Type something to see suggestions persist 
+        <Form>
+          <FormField
+            label="Static suggestions"
+            name="static-suggestions-example"
+            help={`Type something to see suggestions persist 
           regardless of input value.`}
-          htmlFor="text-input-static"
-        >
-          <TextInput
-            id="text-input-static"
-            placeholder="Placeholder text"
-            suggestions={['Apples', 'Oranges', 'Bananas']}
-          />
-        </FormField>
+            htmlFor="text-input-static"
+          >
+            <TextInput
+              name="static-suggestions-example"
+              id="text-input-static"
+              placeholder="Placeholder text"
+              suggestions={['Apples', 'Oranges', 'Bananas']}
+            />
+          </FormField>
+        </Form>
       </Box>
       <Box width="small">
-        <FormField
-          label="Filtered suggestions"
-          help={`Type something to see suggestions filter 
+        <Form>
+          <FormField
+            name="filtered-example"
+            label="Filtered suggestions"
+            help={`Type something to see suggestions filter 
           based on the input value.`}
-          htmlFor="text-input-filtered"
-        >
-          <TextInput
-            id="text-input-filtered"
-            placeholder="Placeholder text"
-            onChange={onChange}
-            onSelect={event => setValue(event.suggestion)}
-            suggestions={suggestions}
-            value={value}
-          />
-        </FormField>
+            htmlFor="text-input-filtered"
+          >
+            <TextInput
+              name="filtered-example"
+              id="text-input-filtered"
+              placeholder="Placeholder text"
+              onChange={onChange}
+              onSelect={event => setValue(event.suggestion)}
+              suggestions={suggestions}
+              value={value}
+            />
+          </FormField>
+        </Form>
       </Box>
     </Box>
   );

--- a/aries-site/src/examples/components/textinput/TextInputSuggestionsExample.js
+++ b/aries-site/src/examples/components/textinput/TextInputSuggestionsExample.js
@@ -23,45 +23,41 @@ export const TextInputSuggestionsExample = () => {
 
   return (
     <Box direction="row-responsive" gap="large" align="end">
-      <Box width="small">
-        <Form>
-          <FormField
-            label="Static suggestions"
-            name="static-suggestions-example"
-            help={`Type something to see suggestions persist 
+      <Form>
+        <FormField
+          label="Static suggestions"
+          name="static-suggestions-example"
+          help={`Type something to see suggestions persist 
           regardless of input value.`}
-            htmlFor="text-input-static"
-          >
-            <TextInput
-              name="static-suggestions-example"
-              id="text-input-static"
-              placeholder="Placeholder text"
-              suggestions={['Apples', 'Oranges', 'Bananas']}
-            />
-          </FormField>
-        </Form>
-      </Box>
-      <Box width="small">
-        <Form>
-          <FormField
-            name="filtered-example"
-            label="Filtered suggestions"
-            help={`Type something to see suggestions filter 
+          htmlFor="text-input-static"
+        >
+          <TextInput
+            name="static-suggestions-example"
+            id="text-input-static"
+            placeholder="Placeholder text"
+            suggestions={['Apples', 'Oranges', 'Bananas']}
+          />
+        </FormField>
+      </Form>
+      <Form>
+        <FormField
+          name="filtered-example"
+          label="Filtered suggestions"
+          help={`Type something to see suggestions filter 
           based on the input value.`}
-            htmlFor="text-input-filtered"
-          >
-            <TextInput
-              name="filtered-example"
-              id="text-input-filtered"
-              placeholder="Placeholder text"
-              onChange={onChange}
-              onSelect={event => setValue(event.suggestion)}
-              suggestions={suggestions}
-              value={value}
-            />
-          </FormField>
-        </Form>
-      </Box>
+          htmlFor="text-input-filtered"
+        >
+          <TextInput
+            name="filtered-example"
+            id="text-input-filtered"
+            placeholder="Placeholder text"
+            onChange={onChange}
+            onSelect={event => setValue(event.suggestion)}
+            suggestions={suggestions}
+            value={value}
+          />
+        </FormField>
+      </Form>
     </Box>
   );
 };

--- a/aries-site/src/examples/components/textinput/TextInputValidationExample.js
+++ b/aries-site/src/examples/components/textinput/TextInputValidationExample.js
@@ -1,35 +1,33 @@
 import React, { useState } from 'react';
-import { Box, Form, FormField, TextInput } from 'grommet';
+import { Form, FormField, TextInput } from 'grommet';
 
 export const TextInputValidationExample = () => {
   const [value, setValue] = useState('');
   const defaultErrorMessage = 'Type something to resolve this error.';
   const [message, setMessage] = useState(defaultErrorMessage);
   return (
-    <Box width="small">
-      <Form>
-        <FormField
+    <Form>
+      <FormField
+        name="required-field"
+        label="Label"
+        htmlFor="required-field"
+        error={message}
+      >
+        <TextInput
           name="required-field"
-          label="Label"
-          htmlFor="required-field"
-          error={message}
-        >
-          <TextInput
-            name="required-field"
-            id="required-field"
-            placeholder="Placeholder text"
-            onChange={event => {
-              if (event.target.value.length > 0) {
-                setMessage('');
-              } else {
-                setMessage(defaultErrorMessage);
-              }
-              setValue(event.target.value);
-            }}
-            value={value}
-          />
-        </FormField>
-      </Form>
-    </Box>
+          id="required-field"
+          placeholder="Placeholder text"
+          onChange={event => {
+            if (event.target.value.length > 0) {
+              setMessage('');
+            } else {
+              setMessage(defaultErrorMessage);
+            }
+            setValue(event.target.value);
+          }}
+          value={value}
+        />
+      </FormField>
+    </Form>
   );
 };


### PR DESCRIPTION
Did a first pass through the components we have put up to remove any extra `boxes`

I found that In `TextInput` there was `box` with `width='small'` but without that there wasnt much change. I did leave the `box` around `search` of `width='medium'` otherwise the search took up majority of the space. 

There is `boxs` around `select` in which they have a `width='medium'` without it the `select` component does get noticeably smaller so if we leave them there thats probably fine or can take a couple out to show the actual size without `box`