### PR TITLE
update component for textinput on preview

### DIFF
--- a/aries-site/src/examples/cardPreviews/textinput.js
+++ b/aries-site/src/examples/cardPreviews/textinput.js
@@ -4,14 +4,16 @@ import { TextInput, FormField } from 'grommet';
 export const TextInputPreview = () => {
   return (
     <FormField
-      style={{ borderRadius: '4px' }}
-      fill="horizontal"
-      border={{ color: 'focus', size: 'small' }}
+      style={{
+        boxShadow: '0 0 2px 2px #00E8CF',
+        borderRadius: '4px',
+      }}
     >
       <TextInput
         aria-label="preview"
-        focusIndicator
-        placeholder="Placeholder text"
+        id="focus-id"
+        name="focus"
+        placeholder="Enter a username"
       />
     </FormField>
   );

--- a/aries-site/src/examples/cardPreviews/textinput.js
+++ b/aries-site/src/examples/cardPreviews/textinput.js
@@ -1,21 +1,24 @@
 import React from 'react';
-import { TextInput, FormField } from 'grommet';
+import { Form, FormField, TextInput } from 'grommet';
 
 export const TextInputPreview = () => {
   return (
-    <FormField
-      htmlFor="focus-id"
-      style={{
-        boxShadow: '0 0 2px 2px #00E8CF',
-        borderRadius: '4px',
-      }}
-    >
-      <TextInput
-        aria-label="preview"
-        id="focus-id"
+    <Form>
+      <FormField
+        htmlFor="focus-id"
         name="focus"
-        placeholder="Enter a username"
-      />
-    </FormField>
+        style={{
+          boxShadow: '0 0 2px 2px #00E8CF',
+          borderRadius: '4px',
+        }}
+      >
+        <TextInput
+          aria-label="preview"
+          id="focus-id"
+          name="focus"
+          placeholder="Enter a username"
+        />
+      </FormField>
+    </Form>
   );
 };

--- a/aries-site/src/examples/cardPreviews/textinput.js
+++ b/aries-site/src/examples/cardPreviews/textinput.js
@@ -4,6 +4,7 @@ import { TextInput, FormField } from 'grommet';
 export const TextInputPreview = () => {
   return (
     <FormField
+      htmlFor="focus-id"
       style={{
         boxShadow: '0 0 2px 2px #00E8CF',
         borderRadius: '4px',


### PR DESCRIPTION
The image on `textinput` preview was not as correct. Originally I wanted to force the focus but that would throw off the accessibility  so I decided to just go with the inline style to match up better with how the focus is in `formfield` 