### PR TITLE
Allow Example to restrict width of child

### DIFF
--- a/aries-site/src/layouts/content/Example.js
+++ b/aries-site/src/layouts/content/Example.js
@@ -91,6 +91,7 @@ export const Example = ({
   figma,
   height,
   template,
+  width,
   ...rest
 }) => {
   const theme = React.useContext(ThemeContext);
@@ -141,10 +142,12 @@ export const Example = ({
             }
             {...rest}
           >
-            {children &&
-              React.cloneElement(children, {
-                mobile,
-              })}
+            <Box width={width}>
+              {children &&
+                React.cloneElement(children, {
+                  mobile,
+                })}
+            </Box>
           </Box>
           {(designer || docs || figma || template) && (
             <ExampleControls
@@ -274,8 +277,10 @@ Example.propTypes = {
   figma: PropTypes.string,
   height: PropTypes.oneOfType([PropTypes.string, PropTypes.object]),
   template: PropTypes.bool,
+  width: PropTypes.oneOfType([PropTypes.string, PropTypes.object]),
 };
 
 Example.defaultProps = {
   height: { min: 'medium' },
+  width: '100%',
 };

--- a/aries-site/src/pages/components/search.js
+++ b/aries-site/src/pages/components/search.js
@@ -32,6 +32,7 @@ const Search = () => {
             designer="https://designer.grommet.io/search?id=HPE-design-system-hpedesignsystem-hpe-com"
             docs="https://v2.grommet.io/textinput?theme=hpe#props"
             figma="https://www.figma.com/file/KKHWJN4GAI0Mq5yh0snDT6/HPE-Search-Component?node-id=265%3A112"
+            width="medium"
           >
             <SearchExample />
           </Example>
@@ -155,6 +156,7 @@ const Search = () => {
             code="https://raw.githubusercontent.com/hpe-design/design-system/master/aries-site/src/examples/components/search/SearchSuggestionsExample.js"
             docs="https://v2.grommet.io/textinput?theme=hpe#props"
             height={{ min: 'small' }}
+            width="medium"
           >
             <SearchSuggestionsExample />
           </Example>
@@ -169,6 +171,7 @@ const Search = () => {
             code="https://raw.githubusercontent.com/hpe-design/design-system/master/aries-site/src/examples/components/search/SearchSimpleExample.js"
             docs="https://v2.grommet.io/textinput?theme=hpe#props"
             height={{ min: 'small' }}
+            width="medium"
           >
             <SearchSimpleExample />
           </Example>
@@ -189,6 +192,7 @@ const Search = () => {
             code="https://raw.githubusercontent.com/hpe-design/design-system/master/aries-site/src/examples/components/search/SearchIconPositionExample.js"
             docs="https://v2.grommet.io/textinput?theme=hpe#props"
             height={{ min: 'small' }}
+            width="medium"
           >
             <SearchIconPositionExample />
           </Example>


### PR DESCRIPTION
Preview: 

After cleaning up boxes from the examples, the Search component was expanding too wide, and this could be an issue for future examples as well. This adds a `width` prop to `Example` that allows us to restrict the width of the Example child without having to clutter the specific example code itself.