### PR TITLE
Display status on page

### DIFF
--- a/aries-site/src/components/content/Status.js
+++ b/aries-site/src/components/content/Status.js
@@ -1,0 +1,78 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Box, Text } from 'grommet';
+import { Figma, Grommet } from 'grommet-icons';
+import { IconCircle, IconTriangle } from '../icons';
+
+const types = {
+  figma: {
+    name: 'Figma',
+    icon: <Figma color="plain" />,
+  },
+  grommet: {
+    name: 'Grommet',
+    icon: <Grommet color="plain" />,
+  },
+};
+
+const statuses = {
+  'In Progress': {
+    icon: <IconTriangle size="small" color="status-warning" />,
+  },
+  Complete: {
+    icon: <IconCircle size="small" color="status-ok" />,
+  },
+};
+
+const StatusBadge = ({ status, type }) => {
+  return (
+    <Box direction="row">
+      <Box
+        background="background-front"
+        pad={{ vertical: 'xsmall', horizontal: 'small' }}
+        round={{ corner: 'left', size: 'xsmall' }}
+        direction="row"
+      >
+        <Box direction="row" gap="xsmall" align="center">
+          {types[type].icon}
+          <Text weight="bold">{type && types[type].name}</Text>
+        </Box>
+      </Box>
+      <Box
+        background="background-contrast"
+        pad={{ vertical: 'xsmall', horizontal: 'small' }}
+        round={{ corner: 'right', size: 'xsmall' }}
+        direction="row"
+        align="center"
+        gap="small"
+      >
+        {statuses[status[type]].icon}
+        <Text weight="bold">{status[type]}</Text>
+      </Box>
+    </Box>
+  );
+};
+
+StatusBadge.propTypes = {
+  status: PropTypes.shape({
+    figma: PropTypes.string,
+    grommet: PropTypes.string,
+  }),
+  type: PropTypes.oneOf(['figma', 'grommet']),
+};
+
+export const Status = ({ status }) => {
+  return (
+    <Box direction="row" gap="medium">
+      {status.figma && <StatusBadge type="figma" status={status} />}
+      {status.grommet && <StatusBadge type="grommet" status={status} />}
+    </Box>
+  );
+};
+
+Status.propTypes = {
+  status: PropTypes.shape({
+    figma: PropTypes.oneOf(['Complete', 'In Progress']),
+    grommet: PropTypes.oneOf(['Complete', 'In Progress']),
+  }),
+};

--- a/aries-site/src/components/content/Status.js
+++ b/aries-site/src/components/content/Status.js
@@ -63,7 +63,7 @@ StatusBadge.propTypes = {
 
 export const Status = ({ status }) => {
   return (
-    <Box direction="row" gap="medium">
+    <Box direction="row-responsive" gap="medium">
       {status.figma && <StatusBadge type="figma" status={status} />}
       {status.grommet && <StatusBadge type="grommet" status={status} />}
     </Box>

--- a/aries-site/src/components/content/index.js
+++ b/aries-site/src/components/content/index.js
@@ -3,5 +3,6 @@ export * from './CollapsibleSection';
 export * from './ComingSoon';
 export * from './PageBackground';
 export * from './SubsectionText';
+export * from './Status';
 export * from './SubmitFeedback';
 export * from './ThemeModeToggle';

--- a/aries-site/src/components/icons/IconTriangle.js
+++ b/aries-site/src/components/icons/IconTriangle.js
@@ -1,0 +1,13 @@
+import React from 'react';
+
+import { Blank } from 'grommet-icons';
+
+export const IconTriangle = props => (
+  <Blank {...props}>
+    <path
+      // eslint-disable-next-line max-len
+      d="M11.1425 2.42915C11.5309 1.78182 12.4691 1.78182 12.8575 2.42915L23.0913 19.4855C23.4912 20.152 23.0111 21 22.2338 21H1.76619C0.988895 21 0.508783 20.152 0.908698 19.4855L11.1425 2.42915Z"
+      fill="#000"
+    />
+  </Blank>
+);

--- a/aries-site/src/components/icons/index.js
+++ b/aries-site/src/components/icons/index.js
@@ -12,6 +12,7 @@ export * from './IconResources';
 export * from './IconSun';
 export * from './IconSquare';
 export * from './IconTemplates';
+export * from './IconTriangle';
 export * from './components';
 export * from './foundation';
 export * from './guidelines';

--- a/aries-site/src/data/structure.js
+++ b/aries-site/src/data/structure.js
@@ -28,6 +28,11 @@ import {
 import { SelectPreview } from '../examples/components/select';
 import { StackExample } from '../examples/components/layouts';
 
+const statuses = {
+  complete: 'Complete',
+  inProgress: 'In Progress',
+};
+
 export const structure = [
   {
     name: 'Home',
@@ -274,6 +279,10 @@ export const structure = [
       },
     },
     relatedContent: ['Button', 'Header', 'Menu', 'Search', 'Global Sidebar'],
+    status: {
+      figma: statuses.inProgress,
+      grommet: statuses.inProgress,
+    },
   },
   {
     name: 'Lists',
@@ -512,6 +521,10 @@ export const structure = [
       'Buttons are used to indicate actions that can be performed.',
     relatedContent: ['Anchor', 'Menu', 'Tabs'],
     sections: [],
+    status: {
+      figma: statuses.complete,
+      grommet: statuses.inProgress,
+    },
     preview: {
       component: () => <ButtonPreview />,
       background: 'background-front',
@@ -600,6 +613,10 @@ export const structure = [
       component: () => <CheckBoxPreview />,
       background: 'background-front',
     },
+    status: {
+      figma: statuses.complete,
+      grommet: statuses.inProgress,
+    },
   },
   {
     name: 'Accordion',
@@ -618,6 +635,10 @@ export const structure = [
     seoDescription:
       'The accordion affords content to be delivered progressively.',
     sections: [],
+    status: {
+      figma: statuses.complete,
+      grommet: statuses.inProgress,
+    },
   },
   {
     name: 'Header',
@@ -664,6 +685,10 @@ export const structure = [
       background: 'background-front',
     },
     relatedContent: ['Header', 'Dashboards', 'Select'],
+    status: {
+      figma: statuses.inProgress,
+      grommet: statuses.inProgress,
+    },
   },
   {
     name: 'Box',
@@ -702,6 +727,10 @@ export const structure = [
     preview: {
       component: () => <LayerPreview />,
     },
+    status: {
+      figma: statuses.inProgress,
+      grommet: statuses.complete,
+    },
   },
   {
     name: 'Main',
@@ -723,6 +752,10 @@ export const structure = [
       background: 'background-front',
     },
     relatedContent: ['TextInput', 'Forms', 'Select'],
+    status: {
+      figma: statuses.inProgress,
+      grommet: statuses.complete,
+    },
   },
 
   {
@@ -736,6 +769,10 @@ export const structure = [
       component: () => <RadioButtonGroupPreview />,
       background: 'background-front',
     },
+    status: {
+      figma: statuses.complete,
+      grommet: statuses.inProgress,
+    },
   },
   {
     name: 'RangeInput',
@@ -747,6 +784,10 @@ export const structure = [
     preview: {
       component: () => <RangeInputPreview />,
       background: 'background-front',
+    },
+    status: {
+      figma: statuses.complete,
+      grommet: statuses.inProgress,
     },
   },
   {

--- a/aries-site/src/layouts/content/Subsection.js
+++ b/aries-site/src/layouts/content/Subsection.js
@@ -46,14 +46,21 @@ export const Subsection = ({
     return undefined;
   });
 
-  const remainingChildren = React.Children.map(children, (child, index) => {
-    if (index === 0) {
-      return undefined;
-    }
-    return React.cloneElement(child, {
-      level,
-    });
-  });
+  // need to filter out children equal to null that occurs if a page
+  // doesn't have any status
+  const filteredChildren = React.Children.toArray(children).filter(o => o);
+
+  const remainingChildren = React.Children.map(
+    filteredChildren,
+    (child, index) => {
+      if (index === 0) {
+        return undefined;
+      }
+      return React.cloneElement(child, {
+        level,
+      });
+    },
+  );
 
   return (
     <Box

--- a/aries-site/src/pages/components/accordion.js
+++ b/aries-site/src/pages/components/accordion.js
@@ -2,7 +2,13 @@ import React from 'react';
 
 import { Text } from 'grommet';
 
-import { CardGrid, Meta, SubsectionText, BulletedList } from '../../components';
+import {
+  CardGrid,
+  Meta,
+  Status,
+  SubsectionText,
+  BulletedList,
+} from '../../components';
 import { ContentSection, Layout, Subsection, Example } from '../../layouts';
 import { AccordionExample } from '../../examples';
 import { getPageDetails, getRelatedContent } from '../../utils';
@@ -22,6 +28,7 @@ const Accordion = () => (
     <ContentSection>
       <Subsection name={title} level={1} topic={topic}>
         <SubsectionText>{page.description}</SubsectionText>
+        {page.status && <Status status={page.status} />}
         <Example
           docs="https://v2.grommet.io/accordion#props"
           designer="https://designer.grommet.io/accordion?id=HPE-design-system-hpedesignsystem-hpe-com"

--- a/aries-site/src/pages/components/box.js
+++ b/aries-site/src/pages/components/box.js
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { Meta, SubsectionText } from '../../components';
+import { Meta, Status, SubsectionText } from '../../components';
 import { ContentSection, Layout, Subsection, Example } from '../../layouts';
 import { BoxExample } from '../../examples';
 import { getPageDetails } from '../../utils';
@@ -22,6 +22,7 @@ const Box = () => (
           Box is where it all starts. Flexible props allow the behavior of
           content to be defined to optimize the user experience.
         </SubsectionText>
+        {page.status && <Status status={page.status} />}
         <Example
           docs="https://v2.grommet.io/box?theme=hpe#props"
           code="https://raw.githubusercontent.com/hpe-design/design-system/master/aries-site/src/examples/components/layouts/BoxExample.js"

--- a/aries-site/src/pages/components/button.js
+++ b/aries-site/src/pages/components/button.js
@@ -1,7 +1,13 @@
 import React from 'react';
 import { Anchor } from 'grommet';
 
-import { BulletedList, CardGrid, Meta, SubsectionText } from '../../components';
+import {
+  BulletedList,
+  CardGrid,
+  Meta,
+  Status,
+  SubsectionText,
+} from '../../components';
 import {
   ButtonExample,
   ButtonIconExample,
@@ -28,9 +34,8 @@ const Button = () => (
     />
     <ContentSection>
       <Subsection name={title} level={1} topic={topic}>
-        <SubsectionText>
-          Buttons are used to indicate actions that can be performed.
-        </SubsectionText>
+        <SubsectionText>{page.description}</SubsectionText>
+        {page.status && <Status status={page.status} />}
         <Example
           docs="https://v2.grommet.io/button?theme=hpe#props"
           code="https://raw.githubusercontent.com/hpe-design/design-system/master/aries-site/src/examples/components/button/ButtonExample.js"

--- a/aries-site/src/pages/components/checkbox.js
+++ b/aries-site/src/pages/components/checkbox.js
@@ -1,7 +1,13 @@
 import React from 'react';
 
 import { Anchor } from 'grommet';
-import { CardGrid, Meta, SubsectionText, BulletedList } from '../../components';
+import {
+  CardGrid,
+  Meta,
+  Status,
+  SubsectionText,
+  BulletedList,
+} from '../../components';
 import { ContentSection, Layout, Subsection, Example } from '../../layouts';
 import {
   CheckBoxDisabledExample,
@@ -27,6 +33,7 @@ const CheckBox = () => (
     <ContentSection>
       <Subsection name={title} level={1} topic={topic}>
         <SubsectionText>{page.description}</SubsectionText>
+        {page.status && <Status status={page.status} />}
         <Example
           docs="https://v2.grommet.io/checkbox?theme=hpe#props"
           code="https://raw.githubusercontent.com/hpe-design/design-system/master/aries-site/src/examples/components/checkbox/CheckBoxSimpleExample.js"

--- a/aries-site/src/pages/components/layer.js
+++ b/aries-site/src/pages/components/layer.js
@@ -2,7 +2,7 @@ import React from 'react';
 
 import { Anchor } from 'grommet';
 
-import { BulletedList, Meta, SubsectionText } from '../../components';
+import { BulletedList, Meta, Status, SubsectionText } from '../../components';
 import { ContentSection, Layout, Subsection, Example } from '../../layouts';
 import { LayerExample } from '../../examples';
 import { getPageDetails, nameToPath } from '../../utils';
@@ -25,6 +25,7 @@ const Layer = () => (
           Modal dialogs, notifications, and help text are just a few
           possibilities.
         </SubsectionText>
+        {page.status && <Status status={page.status} />}
         <Example
           docs="https://v2.grommet.io/layer?theme=hpe#props"
           code="https://raw.githubusercontent.com/hpe-design/design-system/master/aries-site/src/examples/components/layouts/LayerExample.js"

--- a/aries-site/src/pages/components/maskedinput.js
+++ b/aries-site/src/pages/components/maskedinput.js
@@ -1,6 +1,12 @@
 import React from 'react';
 import { Anchor, Text } from 'grommet';
-import { BulletedList, CardGrid, Meta, SubsectionText } from '../../components';
+import {
+  BulletedList,
+  CardGrid,
+  Meta,
+  Status,
+  SubsectionText,
+} from '../../components';
 import {
   MaskedDateExample,
   MaskedDisabledExample,
@@ -31,6 +37,7 @@ const MaskedInput = () => {
       <ContentSection>
         <Subsection name={title} level={1} topic={topic}>
           <SubsectionText>{page.description}</SubsectionText>
+          {page.status && <Status status={page.status} />}
           <Example
             code="https://raw.githubusercontent.com/hpe-design/design-system/master/aries-site/src/examples/components/input/maskedinput/MaskedPhoneExample.js"
             docs="https://v2.grommet.io/maskedinput?theme=hpe#props"

--- a/aries-site/src/pages/components/menu.js
+++ b/aries-site/src/pages/components/menu.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Anchor, Text } from 'grommet';
 
-import { CardGrid, Meta, SubsectionText } from '../../components';
+import { CardGrid, Meta, Status, SubsectionText } from '../../components';
 import {
   MenuExample,
   MenuDisabledExample,
@@ -27,6 +27,7 @@ const Menu = () => {
       <ContentSection>
         <Subsection name={title} level={1} topic={topic}>
           <SubsectionText>{page.description}</SubsectionText>
+          {page.status && <Status status={page.status} />}
           <Example
             code="https://raw.githubusercontent.com/hpe-design/design-system/master/aries-site/src/examples/components/menu/MenuExample.js"
             designer="https://designer.grommet.io/menu?id=HPE-design-system-hpedesignsystem-hpe-com"

--- a/aries-site/src/pages/components/radiobuttongroup.js
+++ b/aries-site/src/pages/components/radiobuttongroup.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Meta, SubsectionText } from '../../components';
+import { Meta, Status, SubsectionText } from '../../components';
 import { RadioButtonGroupExample } from '../../examples';
 import { ContentSection, Example, Layout, Subsection } from '../../layouts';
 import { getPageDetails } from '../../utils';
@@ -19,6 +19,7 @@ const RadioButtonGroup = () => {
       <ContentSection>
         <Subsection name={title} level={1} topic={topic}>
           <SubsectionText>{page.description}</SubsectionText>
+          {page.status && <Status status={page.status} />}
           <Example
             code="https://raw.githubusercontent.com/hpe-design/design-system/master/aries-site/src/examples/components/input/RadioButtonGroupExample.js"
             docs="https://v2.grommet.io/radiobuttongroup?theme=hpe#props"

--- a/aries-site/src/pages/components/rangeinput.js
+++ b/aries-site/src/pages/components/rangeinput.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Meta, SubsectionText } from '../../components';
+import { Meta, Status, SubsectionText } from '../../components';
 import { RangeInputExample } from '../../examples';
 import { ContentSection, Example, Layout, Subsection } from '../../layouts';
 import { getPageDetails } from '../../utils';
@@ -19,6 +19,8 @@ const RangeInput = () => {
       <ContentSection>
         <Subsection name={title} level={1} topic={topic}>
           <SubsectionText>{page.description}</SubsectionText>
+          {page.status && <Status status={page.status} />}
+
           <Example
             code="https://raw.githubusercontent.com/hpe-design/design-system/master/aries-site/src/examples/components/input/RangeInputExample.js"
             docs="https://v2.grommet.io/rangeinput?theme=hpe#props"

--- a/aries-site/src/pages/foundation/icons.js
+++ b/aries-site/src/pages/foundation/icons.js
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import { Anchor, Button } from 'grommet';
-import { Meta, SubsectionText } from '../../components';
+import { Meta, Status, SubsectionText } from '../../components';
 import {
   ButtonRow,
   Layout,
@@ -45,6 +45,7 @@ const Icons = () => {
             may be beneficial to pair icons with text to ensure the use of the
             icon is properly understood.
           </SubsectionText>
+          {pageDetails.status && <Status status={pageDetails.status} />}
         </Subsection>
         <ButtonRow>
           <Button

--- a/aries-site/src/pages/templates/dashboards.js
+++ b/aries-site/src/pages/templates/dashboards.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { CardGrid, Meta, SubsectionText } from '../../components';
+import { CardGrid, Meta, Status, SubsectionText } from '../../components';
 import { DashboardExample } from '../../examples';
 import { ContentSection, Example, Layout, Subsection } from '../../layouts';
 import { getPageDetails, getRelatedContent } from '../../utils';
@@ -23,6 +23,7 @@ const Dashboards = () => {
             At-a-glance preview for operation critical information with easy
             access to areas requiring attention.
           </SubsectionText>
+          {page.status && <Status status={page.status} />}
           <Example
             code="https://raw.githubusercontent.com/hpe-design/design-system/master/aries-site/src/examples/templates/dashboards/DashboardExample.js"
             template

--- a/aries-site/src/pages/templates/lists.js
+++ b/aries-site/src/pages/templates/lists.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Meta, SubsectionText } from '../../components';
+import { Meta, Status, SubsectionText } from '../../components';
 import { ListScreenExample } from '../../examples';
 import { ContentSection, Example, Layout, Subsection } from '../../layouts';
 import { getPageDetails } from '../../utils';
@@ -28,6 +28,7 @@ const Lists = () => {
             Each list item provides users focussed information and identity
             labels to aid selection, decision making, and action.
           </SubsectionText>
+          {page.status && <Status status={page.status} />}
         </Subsection>
       </ContentSection>
       <ContentSection>


### PR DESCRIPTION
Preview: https://deploy-preview-754--keen-mayer-a86c8b.netlify.app/components/button

Allow figma and grommet status to be displayed on details page. I've created a reusable component called <Status /> that takes a status prop. In structure.js we can define and object called status for any page.

For pages that are complete on both the grommet and figma side, no status is displayed. However, for those are are in progress either on grommet or figma or both, a status should be shown. I've added statuses to the pages I think need them based on this criteria, but if I've missed any let me know.

Closes #731 