### PR TITLE
Smooth card elevation animation

### DIFF
--- a/aries-site/src/components/cards/CardGrid.js
+++ b/aries-site/src/components/cards/CardGrid.js
@@ -21,7 +21,11 @@ export const CardGrid = ({ cards, ...rest }) => {
         cards.map(topic => (
           <Link key={topic.name} href={nameToPath(topic.name)} passHref>
             <ContentCard
-              as="a"
+              /* forwardedAs maintains styling provided by Higher Order 
+              Components. Styled-Components 4.3.0 docs: https://styled-components.com/docs/api#forwardedas-prop
+              https://github.com/styled-components/styled-components/issues/1981#issuecomment-548860710
+              */
+              forwardedAs="a"
               style={{ textDecoration: 'none' }}
               topic={topic}
             />

--- a/aries-site/src/components/cards/ContentCard.js
+++ b/aries-site/src/components/cards/ContentCard.js
@@ -22,7 +22,7 @@ export const ContentCard = forwardRef(({ topic, ...rest }, ref) => {
     <StyledTile
       align="start"
       background="background-front"
-      elevation={isFocused ? 'medium' : 'xsmall'}
+      elevation={isFocused ? 'medium' : 'small'}
       fill
       onBlur={() => setIsFocused(false)}
       onFocus={() => setIsFocused(true)}

--- a/aries-site/src/components/cards/ContentCard.js
+++ b/aries-site/src/components/cards/ContentCard.js
@@ -1,19 +1,28 @@
 import React, { forwardRef } from 'react';
+import styled from 'styled-components';
 import PropTypes from 'prop-types';
 import { Box, Image, Text } from 'grommet';
 import { Identifier, Tile } from 'aries-core';
 import { PreviewImageCard } from './PreviewCard';
 import { useDarkMode } from '../../utils';
 
+const StyledTile = styled(Tile)`
+  transition: all 0.3s ease-in-out;
+  :focus,
+  :hover {
+    transform: scale(1.01, 1.01);
+  }
+`;
+
 export const ContentCard = forwardRef(({ topic, ...rest }, ref) => {
   const { description, name, parent, preview } = topic;
   const [isFocused, setIsFocused] = React.useState(false);
   const darkMode = useDarkMode();
   return (
-    <Tile
+    <StyledTile
       align="start"
       background="background-front"
-      elevation={isFocused ? 'medium' : 'none'}
+      elevation={isFocused ? 'medium' : 'xsmall'}
       fill
       onBlur={() => setIsFocused(false)}
       onFocus={() => setIsFocused(true)}
@@ -61,7 +70,7 @@ export const ContentCard = forwardRef(({ topic, ...rest }, ref) => {
           <Text size="small">{description}</Text>
         </Box>
       </Box>
-    </Tile>
+    </StyledTile>
   );
 });
 


### PR DESCRIPTION
Closes https://github.com/hpe-design/design-system/issues/782

[Slack Convo](https://hpe.slack.com/archives/GPPLUK6LR/p1589234074012300)

[Preview](https://deploy-preview-776--keen-mayer-a86c8b.netlify.app/)

Adds smoother animation to cards on hover.