### PR TITLE
replace button for figma

### DIFF
--- a/aries-site/src/pages/foundation/color.js
+++ b/aries-site/src/pages/foundation/color.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { Figma } from 'grommet-icons';
 import { Anchor, Box, Button, ResponsiveContext } from 'grommet';
 
 import {
@@ -78,18 +79,10 @@ const Color = () => (
               </SubsectionText>
               <ButtonRow>
                 <Button
-                  href="https://theme-designer.grommet.io/Dashboard?id=HPE2a-eric-soderberg-hpe-com"
-                  label="Use the Colors"
-                  primary
+                  href='https://www.figma.com/file/eZYR3dtWdb9U90QvJ7p3T9/hpe-design-system-library-color'
+                  icon={<Figma color="plain" />}
+                  label="Open in Figma"
                   target="_blank"
-                  rel="noreferrer noopener"
-                />
-                <Button
-                  href="https://www.figma.com/file/eZYR3dtWdb9U90QvJ7p3T9/hpe-design-system-library-color"
-                  label="See in Figma"
-                  primary
-                  target="_blank"
-                  rel="noreferrer noopener"
                 />
               </ButtonRow>
             </Subsection>

--- a/aries-site/src/pages/foundation/color.js
+++ b/aries-site/src/pages/foundation/color.js
@@ -83,7 +83,7 @@ const Color = () => (
                   icon={<Figma color="plain" />}
                   label="Open in Figma"
                   target="_blank"
-                  primary
+                  secondary
                 />
               </ButtonRow>
             </Subsection>

--- a/aries-site/src/pages/foundation/color.js
+++ b/aries-site/src/pages/foundation/color.js
@@ -83,6 +83,7 @@ const Color = () => (
                   icon={<Figma color="plain" />}
                   label="Open in Figma"
                   target="_blank"
+                  primary
                 />
               </ButtonRow>
             </Subsection>


### PR DESCRIPTION
[Preview](https://deploy-preview-778--keen-mayer-a86c8b.netlify.app/foundation/color)
closes #777 

There was 2 links for colors one figma and one designer. Figma button should be updated to how we have the other figma Buttons in components. As of now not sure of what the benefits of having Designer link for colors. 
We can have a colors screen. in designer but that would match the figma page which may be overkill