### PR TITLE
Add variant for CheckBoxGroup with array of objects for options

### DIFF
--- a/aries-site/src/examples/components/checkboxgroup/CheckBoxGroupObjectExample.js
+++ b/aries-site/src/examples/components/checkboxgroup/CheckBoxGroupObjectExample.js
@@ -1,0 +1,29 @@
+import React from 'react';
+import { CheckBoxGroup, Form, FormField } from 'grommet';
+
+const objectOptions = [];
+for (let i = 1; i <= 3; i += 1) {
+  objectOptions.push({
+    label: `Option ${i}`,
+    val: i,
+  });
+}
+
+export const CheckBoxGroupObjectExample = () => {
+  return (
+    <Form>
+      <FormField
+        name="checkboxgroup-objectoptions"
+        fill
+        htmlFor="objectoptions-checkboxgroup"
+        label="Label"
+      >
+        <CheckBoxGroup
+          options={objectOptions}
+          name="checkboxgroup-objectoptions"
+          id="objectoptions-checkboxgroup"
+        />
+      </FormField>
+    </Form>
+  );
+};

--- a/aries-site/src/examples/components/checkboxgroup/CheckBoxGroupObjectExample.js
+++ b/aries-site/src/examples/components/checkboxgroup/CheckBoxGroupObjectExample.js
@@ -22,6 +22,7 @@ export const CheckBoxGroupObjectExample = () => {
           options={objectOptions}
           name="checkboxgroup-objectoptions"
           id="objectoptions-checkboxgroup"
+          valueKey="val"
         />
       </FormField>
     </Form>

--- a/aries-site/src/examples/components/checkboxgroup/index.js
+++ b/aries-site/src/examples/components/checkboxgroup/index.js
@@ -1,4 +1,5 @@
 export * from './CheckBoxGroupDescriptionExample';
 export * from './CheckBoxGroupDisabledExample';
+export * from './CheckBoxGroupObjectExample';
 export * from './CheckBoxGroupSimpleExample';
 export * from './CheckBoxGroupValidationExample';

--- a/aries-site/src/pages/components/checkboxgroup.js
+++ b/aries-site/src/pages/components/checkboxgroup.js
@@ -12,6 +12,7 @@ import { ContentSection, Layout, Subsection, Example } from '../../layouts';
 import {
   CheckBoxGroupDisabledExample,
   CheckBoxGroupDescriptionExample,
+  CheckBoxGroupObjectExample,
   CheckBoxGroupSimpleExample,
   CheckBoxGroupValidationExample,
 } from '../../examples/components/checkboxgroup';
@@ -105,7 +106,7 @@ const CheckBoxGroup = () => (
           be selected.
         </SubsectionText>
       </Subsection>
-      <Subsection name="CheckBox with Description" level={3}>
+      <Subsection name="With description" level={3}>
         <SubsectionText>
           Adding a description provides the user additional information about
           the context or purpose of the CheckBoxGroup.
@@ -129,6 +130,19 @@ const CheckBoxGroup = () => (
           height={{ min: 'small' }}
         >
           <CheckBoxGroupValidationExample />
+        </Example>
+      </Subsection>
+      <Subsection name="With options as array of objects" level={3}>
+        <SubsectionText>
+          CheckBoxGroup options are typically an array of strings, but they can
+          also be an array of objects.
+        </SubsectionText>
+        <Example
+          //   docs="https://v2.grommet.io/checkboxgroup?theme=hpe#props"
+          code="https://raw.githubusercontent.com/hpe-design/design-system/master/aries-site/src/examples/components/checkboxgroup/CheckBoxGroupObjectExample.js"
+          height={{ min: 'small' }}
+        >
+          <CheckBoxGroupObjectExample />
         </Example>
       </Subsection>
       <Subsection name="Disabled" level={3}>

--- a/yarn.lock
+++ b/yarn.lock
@@ -3259,9 +3259,9 @@ aws-sign2@~0.7.0:
   integrity sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=
 
 aws4@^1.8.0:
-  version "1.9.1"
-  resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.9.1.tgz#7e33d8f7d449b3f673cd72deb9abdc552dbe528e"
-  integrity sha512-wMHVg2EOHaMRxbzgFJ9gtjOOCrI80OHLG14rxi28XwOW8ux6IiEbRCGGGqCtdAIg4FQCbW20k9RsT4y3gJlFug==
+  version "1.10.0"
+  resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.10.0.tgz#a17b3a8ea811060e74d47d306122400ad4497ae2"
+  integrity sha512-3YDiu347mtVtjpyV3u5kVqQLP242c06zwDOgpeRnybmXlYYsLbtTrUBUm8i8srONt+FWobl5aibnU1030PeeuA==
 
 axe-core@^3.4.2:
   version "3.5.3"
@@ -7745,8 +7745,8 @@ graphlib@^2.1.5:
 
 grommet-icons@^4.2.0, "grommet-icons@https://github.com/grommet/grommet-icons/tarball/stable":
   version "4.4.0"
-  uid "730b0a14d9414f4ec2bf4c13c7357c1c41bd4913"
-  resolved "https://github.com/grommet/grommet-icons/tarball/stable#730b0a14d9414f4ec2bf4c13c7357c1c41bd4913"
+  uid "8d3b2ebee6cb6b2201cc258c5df2f3fccd75afcd"
+  resolved "https://github.com/grommet/grommet-icons/tarball/stable#8d3b2ebee6cb6b2201cc258c5df2f3fccd75afcd"
   dependencies:
     grommet-styles "^0.2.0"
 
@@ -9345,9 +9345,9 @@ js-tokens@^3.0.0, js-tokens@^3.0.2:
   integrity sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==
 
 js-yaml@^3.13.1:
-  version "3.13.1"
-  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.13.1.tgz#aff151b30bfdfa8e49e05da22e7415e9dfa37847"
-  integrity sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==
+  version "3.14.0"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.14.0.tgz#a7a34170f26a21bb162424d8adacb4113a69e482"
+  integrity sha512-/4IbIeHcD9VMHFqDR/gQ7EdZdLimOvW2DdcxFjdyyZ9NsbS+ccrXqVWDtab/lRl5AlUqmpBx8EhPaWR+OtY17A==
   dependencies:
     argparse "^1.0.7"
     esprima "^4.0.0"


### PR DESCRIPTION
Adds a variant demonstrating that options can be an array of objects as opposed to just an array of strings.