### PR TITLE
Use text for color of Extend icon

### DIFF
--- a/aries-site/src/data/structure.js
+++ b/aries-site/src/data/structure.js
@@ -138,7 +138,7 @@ export const structure = [
   },
   {
     name: 'Extend',
-    color: 'black',
+    color: 'text',
     description:
       'Why does HPE have a design system? All the aesthetics, best practices, and information about the platform and how to wield it.',
     icon: (size, color) => <IconExtend size={size} color={color} />,

--- a/aries-site/src/data/structure.js
+++ b/aries-site/src/data/structure.js
@@ -138,7 +138,7 @@ export const structure = [
   },
   {
     name: 'Extend',
-    color: 'text',
+    color: 'text-strong',
     description:
       'Why does HPE have a design system? All the aesthetics, best practices, and information about the platform and how to wield it.',
     icon: (size, color) => <IconExtend size={size} color={color} />,


### PR DESCRIPTION
Use 'text' so that in dark mode, the text color will change appropriately.

Closes #775 