### PR TITLE
fix propTypes lint error on _app.js

### DIFF
--- a/aries-site/src/pages/_app.js
+++ b/aries-site/src/pages/_app.js
@@ -1,10 +1,11 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import { ThemeMode } from '../layouts';
 /* _app.js allows for customizing Next.js's default <App> component
  * Details: https://nextjs.org/docs/advanced-features/custom-app
- * 
- * The `Component` prop is the active `page`, so whenever you 
- * navigate between routes, `Component` will change to the new `page`. 
+ *
+ * The `Component` prop is the active `page`, so whenever you
+ * navigate between routes, `Component` will change to the new `page`.
  */
 function App({ Component, pageProps }) {
   return (
@@ -16,5 +17,10 @@ function App({ Component, pageProps }) {
     </ThemeMode>
   );
 }
+
+App.propTypes = {
+  Component: PropTypes.element,
+  pageProps: PropTypes.object,
+};
 
 export default App;


### PR DESCRIPTION
Was getting a lint error for missing PropTypes. This adds prop types on _app.js.