### PR TITLE
Remove statuses from checkbox/checkboxgroup

### DIFF
--- a/aries-site/src/data/structures/components.js
+++ b/aries-site/src/data/structures/components.js
@@ -144,10 +144,6 @@ export const components = [
       component: () => <CheckBoxPreview />,
       background: 'background-front',
     },
-    status: {
-      figma: statuses.complete,
-      grommet: statuses.inProgress,
-    },
   },
   {
     name: 'CheckBoxGroup',
@@ -161,10 +157,6 @@ export const components = [
     preview: {
       component: () => <CheckBoxGroupPreview />,
       background: 'background-front',
-    },
-    status: {
-      figma: statuses.complete,
-      grommet: statuses.inProgress,
     },
   },
   {


### PR DESCRIPTION
As of now, checkbox and checkbox group have been marked as "complete" in design and dev. This removes the status badges.