### PR TITLE
Add Notifications placeholder page

### DIFF
--- a/aries-site/src/data/structures/templates.js
+++ b/aries-site/src/data/structures/templates.js
@@ -157,4 +157,13 @@ export const templates = [
       'RadioButtonGroup',
     ],
   },
+  {
+    name: 'Notifications',
+    available: false,
+    description: `Notifications are a helpful way to notify a user of changes 
+    to application state or to prompt action from a user.`,
+    seoDescription: 'HPE Design System notification examples and templates.',
+    sections: [],
+    relatedContent: [],
+  },
 ];

--- a/aries-site/src/pages/templates/notifications.js
+++ b/aries-site/src/pages/templates/notifications.js
@@ -1,0 +1,27 @@
+import React from 'react';
+
+import { ComingSoon, Meta } from '../../components';
+import { ContentSection, Layout, Subsection } from '../../layouts';
+import { getPageDetails } from '../../utils';
+
+const title = 'Notifications';
+const topic = 'Templates';
+const pageDetails = getPageDetails(title);
+
+const Notifications = () => {
+  return (
+    <Layout title={title}>
+      <Meta
+        title={title}
+        description={pageDetails.seoDescription}
+        canonicalUrl="https://design-system.hpe.design/extend/notifications"
+      />
+      <ContentSection>
+        <Subsection name={title} level={1} topic={topic} />
+      </ContentSection>
+      <ComingSoon />
+    </Layout>
+  );
+};
+
+export default Notifications;


### PR DESCRIPTION
Adds in placeholder page for Notifications. We will need to fill in the preview image once it has been created.

Closes #676 