### PR TITLE
Placeholder page for tables

### DIFF
--- a/aries-site/src/data/structures/templates.js
+++ b/aries-site/src/data/structures/templates.js
@@ -157,4 +157,12 @@ export const templates = [
       'RadioButtonGroup',
     ],
   },
+  {
+    name: 'Tables',
+    available: false,
+    description: 'Common table use cases.',
+    seoDescription: 'HPE Design System table examples and templates.',
+    sections: [],
+    relatedContent: [],
+  },
 ];

--- a/aries-site/src/pages/templates/tables.js
+++ b/aries-site/src/pages/templates/tables.js
@@ -1,0 +1,27 @@
+import React from 'react';
+
+import { ComingSoon, Meta } from '../../components';
+import { ContentSection, Layout, Subsection } from '../../layouts';
+import { getPageDetails } from '../../utils';
+
+const title = 'Tables';
+const topic = 'Templates';
+const pageDetails = getPageDetails(title);
+
+const Tables = () => {
+  return (
+    <Layout title={title}>
+      <Meta
+        title={title}
+        description={pageDetails.seoDescription}
+        canonicalUrl="https://design-system.hpe.design/extend/tables"
+      />
+      <ContentSection>
+        <Subsection name={title} level={1} topic={topic} />
+      </ContentSection>
+      <ComingSoon />
+    </Layout>
+  );
+};
+
+export default Tables;


### PR DESCRIPTION
Creates placeholder for tables templates. Preview image will need to be added once it has been created.

Closes #675 