### PR TITLE
Update previews so that preview components cannot receive tab focus

### DIFF
--- a/aries-site/src/examples/cardPreviews/SearchPreview.js
+++ b/aries-site/src/examples/cardPreviews/SearchPreview.js
@@ -2,4 +2,4 @@ import React from 'react';
 
 import { SearchExample } from '../components/search';
 
-export const SearchPreview = () => <SearchExample />;
+export const SearchPreview = () => <SearchExample tabIndex={-1} />;

--- a/aries-site/src/examples/cardPreviews/button.js
+++ b/aries-site/src/examples/cardPreviews/button.js
@@ -3,5 +3,5 @@ import { Button } from 'grommet';
 import { FormNext } from 'grommet-icons';
 
 export const ButtonPreview = () => {
-  return <Button label="Button" icon={<FormNext />} reverse />;
+  return <Button label="Button" icon={<FormNext />} reverse tabIndex={-1} />;
 };

--- a/aries-site/src/examples/cardPreviews/checkbox.js
+++ b/aries-site/src/examples/cardPreviews/checkbox.js
@@ -3,8 +3,8 @@ import { CheckBox, FormField } from 'grommet';
 
 export const CheckBoxPreview = () => {
   return (
-    <FormField fill='horizontal'>
-      <CheckBox  aria-label="preview" checked label="Value" />
+    <FormField fill="horizontal" tabIndex={-1}>
+      <CheckBox aria-label="preview" checked label="Value" tabIndex={-1} />
     </FormField>
   );
 };

--- a/aries-site/src/examples/cardPreviews/checkboxgroup.js
+++ b/aries-site/src/examples/cardPreviews/checkboxgroup.js
@@ -9,9 +9,14 @@ export const CheckBoxGroupPreview = () => {
         fill="horizontal"
         htmlFor="preview-checkboxgroup"
         label="Label"
+        tabIndex={-1}
       >
         <CheckBoxGroup
-          options={['Option 1', 'Option 2', 'Option 3']}
+          options={[
+            { label: 'Option 1', tabIndex: -1 },
+            { label: 'Option 2', tabIndex: -1 },
+            { label: 'Option 3', tabIndex: -1 },
+          ]}
           value={['Option 2']}
           name="checkboxgroup-preview"
           id="simple-checkboxgroup"

--- a/aries-site/src/examples/cardPreviews/header.js
+++ b/aries-site/src/examples/cardPreviews/header.js
@@ -10,7 +10,7 @@ export const HeaderPreview = () => {
       fill="horizontal"
     >
       <Box direction="row">
-        <Button icon={<Hpe color="brand" />} />
+        <Button icon={<Hpe color="brand" />} tabIndex={-1} />
         <Box gap="xsmall" direction="row">
           <Text weight="bold" alignSelf="center">
             {' '}
@@ -19,7 +19,7 @@ export const HeaderPreview = () => {
           <Text alignSelf="center"> Text</Text>
         </Box>
       </Box>
-      <Button icon={<Menu />} />
+      <Button icon={<Menu />} tabIndex={-1} />
     </Header>
   );
 };

--- a/aries-site/src/examples/cardPreviews/maskedinput.js
+++ b/aries-site/src/examples/cardPreviews/maskedinput.js
@@ -18,6 +18,7 @@ export const MaskedInputPreview = () => {
           placeholder: 'ap',
         },
       ]}
+      tabIndex={-1}
     />
   );
 };

--- a/aries-site/src/examples/cardPreviews/menu.js
+++ b/aries-site/src/examples/cardPreviews/menu.js
@@ -4,7 +4,7 @@ import { Box, Menu } from 'grommet';
 export const MenuPreview = () => {
   return (
     <Box round="xsmall">
-      <Menu label="Menu" width="medium" />
+      <Menu label="Menu" width="medium" tabIndex={-1} />
     </Box>
   );
 };

--- a/aries-site/src/examples/cardPreviews/radiobuttonGroup.js
+++ b/aries-site/src/examples/cardPreviews/radiobuttonGroup.js
@@ -7,9 +7,9 @@ export const RadioButtonGroupPreview = () => {
       name="radio"
       aria-label="preview"
       options={[
-        { label: 'Choice 1', value: 'c1' },
-        { label: 'Choice 2', value: 'c2' },
-        { label: 'Choice 3', value: 'c3' },
+        { label: 'Choice 1', value: 'c1', tabIndex: -1 },
+        { label: 'Choice 2', value: 'c2', tabIndex: -1 },
+        { label: 'Choice 3', value: 'c3', tabIndex: -1 },
       ]}
     />
   );

--- a/aries-site/src/examples/cardPreviews/rangeinput.js
+++ b/aries-site/src/examples/cardPreviews/rangeinput.js
@@ -2,5 +2,13 @@ import React from 'react';
 import { RangeInput } from 'grommet';
 
 export const RangeInputPreview = () => {
-  return <RangeInput aria-label="preview" max={100} min={0} value={80} />;
+  return (
+    <RangeInput
+      aria-label="preview"
+      max={100}
+      min={0}
+      value={80}
+      tabIndex={-1}
+    />
+  );
 };

--- a/aries-site/src/examples/cardPreviews/tabs.js
+++ b/aries-site/src/examples/cardPreviews/tabs.js
@@ -4,9 +4,9 @@ import { Tabs, Tab } from 'grommet';
 export const TabsPreview = () => {
   return (
     <Tabs>
-      <Tab title="Tab 1"/>
-      <Tab title="Tab 2" />
-      <Tab title="Tab 3" />
+      <Tab title="Tab 1" tabIndex={-1} />
+      <Tab title="Tab 2" tabIndex={-1} />
+      <Tab title="Tab 3" tabIndex={-1} />
     </Tabs>
   );
 };

--- a/aries-site/src/examples/cardPreviews/textarea.js
+++ b/aries-site/src/examples/cardPreviews/textarea.js
@@ -2,5 +2,7 @@ import React from 'react';
 import { TextArea } from 'grommet';
 
 export const TextAreaPreview = () => {
-  return <TextArea aria-label="preview" placeholder="Placeholder" />;
+  return (
+    <TextArea aria-label="preview" placeholder="Placeholder" tabIndex={-1} />
+  );
 };

--- a/aries-site/src/examples/cardPreviews/textinput.js
+++ b/aries-site/src/examples/cardPreviews/textinput.js
@@ -17,6 +17,7 @@ export const TextInputPreview = () => {
           id="focus-id"
           name="focus"
           placeholder="Enter a username"
+          tabIndex={-1}
         />
       </FormField>
     </Form>

--- a/aries-site/src/examples/components/search/SearchExample.js
+++ b/aries-site/src/examples/components/search/SearchExample.js
@@ -12,7 +12,7 @@ const StyledTextInput = styled(TextInput).attrs(() => ({
   'aria-labelledby': 'search-icon',
 }))``;
 
-export const SearchExample = () => {
+export const SearchExample = ({ ...props }) => {
   const [value, setValue] = React.useState();
 
   return (
@@ -22,6 +22,7 @@ export const SearchExample = () => {
       reverse
       value={value}
       onChange={event => setValue(event.target.value)}
+      {...props}
     />
   );
 };

--- a/aries-site/src/examples/components/select/SelectPreview.js
+++ b/aries-site/src/examples/components/select/SelectPreview.js
@@ -3,6 +3,11 @@ import { Select } from 'grommet';
 
 export const SelectPreview = () => {
   return (
-    <Select aria-label="preview" options={['First']} placeholder="Choices" />
+    <Select
+      aria-label="preview"
+      options={['First']}
+      placeholder="Choices"
+      disabled
+    />
   );
 };


### PR DESCRIPTION
Removes tab access to component previews. As a user tabs through the homepage (or navpages), tab focus should be placed only on the cards and not on the component previews. Using tabIndex of -1 so disable tab focus. In the case of select, the tabIndex was not being placed on the dropbutton, so I had to use `disabled`.