### PR TITLE
Fix how getTabCount works

### DIFF
--- a/aries-site/src/tests/navigation/homepage.js
+++ b/aries-site/src/tests/navigation/homepage.js
@@ -39,14 +39,14 @@ test('should navigate to correct tile in home page when clicked on', async t => 
 // once it has been resolved, but don't want to block other tests from running
 // as we make commits
 // eslint-disable-next-line max-len
-// test('should navigate to correct path in home page tile when choosen via keyboard', async t => {
-//   const page = 'Color';
-//   const element = Selector('a').withText(page);
-//   const expectedPath = await element.getAttribute('href');
+test('should navigate to correct path in home page tile when choosen via keyboard', async t => {
+  const page = 'Color';
+  const element = Selector('a').withText(page);
+  const expectedPath = await element.getAttribute('href');
 
-//   await t
-//     .pressKey(await repeatKeyPress('tab', await getTabCount(expectedPath)))
-//     .pressKey('enter')
-//     .expect(getLocation())
-//     .contains(expectedPath);
-// });
+  await t
+    .pressKey(await repeatKeyPress('tab', await getTabCount(expectedPath)))
+    .pressKey('enter')
+    .expect(getLocation())
+    .contains(expectedPath);
+});

--- a/aries-site/src/tests/utils.js
+++ b/aries-site/src/tests/utils.js
@@ -22,8 +22,12 @@ export const repeatKeyPress = ClientFunction((key, number) => {
 
 // find how many tabs it takes to reach desired element
 export const getTabCount = ClientFunction(expectedPath => {
-  const tabbableElements = document.querySelectorAll(`button, body [href], 
-  input, select, textarea, [tabindex]:not([tabindex="-1"])`);
+  const tabbableElements = document.querySelectorAll(`
+    button[tabindex]:not([tabindex="-1"]), button[id="search-button"], 
+    input[tabindex]:not([tabindex="-1"]), body [href], 
+    input[tabindex]:not([tabindex="-1"]), 
+    select[tabindex]:not([tabindex="-1"]), 
+    textarea[tabindex]:not([tabindex="-1"]), [tabindex]:not([tabindex="-1"])`);
 
   let hrefIndex;
   for (let i = 0; i < tabbableElements.length; i += 1) {
@@ -38,8 +42,12 @@ export const getTabCount = ClientFunction(expectedPath => {
 });
 
 export const tabToSearch = ClientFunction(() => {
-  const tabbableElements = document.querySelectorAll(`button, body [href], 
-  input, select, textarea, [tabindex]:not([tabindex="-1"])`);
+  const tabbableElements = document.querySelectorAll(`
+  button[tabindex]:not([tabindex="-1"]), button[id="search-button"], 
+    input[tabindex]:not([tabindex="-1"]), body [href], 
+    input[tabindex]:not([tabindex="-1"]), 
+    select[tabindex]:not([tabindex="-1"]), 
+    textarea[tabindex]:not([tabindex="-1"]), [tabindex]:not([tabindex="-1"])`);
 
   let tabCount;
   for (let i = 0; i < tabbableElements.length; i += 1) {


### PR DESCRIPTION
To properly index how many tabs it takes to reach an element, we need to omit any elements that explicitly have tabIndex = -1. Additionally, the search button was not getting picked up so we need to explicitly grab it via its id.

This allows us to uncomment the broken homepage test.

Closes #835 