### PR TITLE
Fix docs link

### DIFF
--- a/aries-site/src/layouts/content/ExampleControls.js
+++ b/aries-site/src/layouts/content/ExampleControls.js
@@ -58,7 +58,7 @@ export const ExampleControls = ({ designer, docs, figma, setShowLayer }) => (
       )}
       {docs && (
         <Button
-          href={figma}
+          href={docs}
           icon={<Document />}
           label="Open docs"
           target="_blank"


### PR DESCRIPTION
"Open docs" button will now open to docs link. 

Closes #845 