### PR TITLE
Designer button label

### DIFF
--- a/aries-site/src/layouts/content/ExampleControls.js
+++ b/aries-site/src/layouts/content/ExampleControls.js
@@ -44,7 +44,7 @@ export const ExampleControls = ({ designer, docs, figma, setShowLayer }) => (
         <Button
           href={designer}
           icon={<Grommet color="plain" />}
-          label="Open in Grommet"
+          label="Open in Grommet Designer"
           target="_blank"
         />
       )}

--- a/aries-site/src/layouts/content/ExampleControls.js
+++ b/aries-site/src/layouts/content/ExampleControls.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Box, Button } from 'grommet';
+import { Box, Button, Grid } from 'grommet';
 import { Document, Expand, Grommet, Figma } from 'grommet-icons';
 
 const ControlButton = ({ children, ...rest }) => (
@@ -39,7 +39,13 @@ export const ExampleControls = ({ designer, docs, figma, setShowLayer }) => (
     pad={{ horizontal: 'medium', vertical: 'small' }}
     round={{ corner: 'bottom', size: 'small' }}
   >
-    <Box direction="row-responsive" gap="small">
+    <Grid
+      columns={{ count: 'fill', size: ['small', 'auto'] }}
+      alignSelf="center"
+      justify="start"
+      fill
+      gap="xsmall"
+    >
       {designer && (
         <Button
           href={designer}
@@ -64,7 +70,7 @@ export const ExampleControls = ({ designer, docs, figma, setShowLayer }) => (
           target="_blank"
         />
       )}
-    </Box>
+    </Grid>
     <Button
       icon={<Expand />}
       label="See Fullscreen"


### PR DESCRIPTION
Closes https://github.com/hpe-design/design-system/issues/863

**Changes**
- Changed designer button label to read "Open in Grommet Designer"
- Changed Example control buttons to be lain out in Grid for better responsiveness and button alignment/justification
  - When reviewing, please include Safari - as Grid can be more fussy there ;).