### PR TITLE
POC Page Layouts

### DIFF
--- a/aries-site/src/examples/templates/index.js
+++ b/aries-site/src/examples/templates/index.js
@@ -2,4 +2,5 @@ export * from './dashboards';
 export * from './forms';
 export * from './hub-spoke-navigation';
 export * from './list-views';
+export * from './page-layouts';
 export * from './persistent-navigation';

--- a/aries-site/src/examples/templates/page-layouts/HeaderFooterExample.js
+++ b/aries-site/src/examples/templates/page-layouts/HeaderFooterExample.js
@@ -1,0 +1,47 @@
+import React from 'react';
+import { Header, Box, Footer, Main, ResponsiveContext, Text } from 'grommet';
+
+export const HeaderFooterExample = () => {
+  return (
+    <AppContainer>
+      <Box flex overflow="auto">
+        <Box height={{ min: '100%' }} gap="small">
+          <Header
+            fill="horizontal"
+            height="xxsmall"
+            background="green!"
+            pad="small"
+          >
+            <Text weight="bold" color="text-strong">
+              Header
+            </Text>
+          </Header>
+          <Main flex="grow" fill={undefined} background="orange" pad="small">
+            <Text weight="bold">Main</Text>
+          </Main>
+          <Footer
+            fill="horizontal"
+            height="xxsmall"
+            background="blue"
+            pad="small"
+          >
+            <Text weight="bold">Footer</Text>
+          </Footer>
+        </Box>
+      </Box>
+    </AppContainer>
+  );
+};
+
+const AppContainer = ({ ...rest }) => {
+  const size = React.useContext(ResponsiveContext);
+  return (
+    <Box
+      direction={size === 'small' ? 'column-reverse' : 'row'}
+      height={size === 'small' ? { max: 'large' } : '100%'}
+      width={size === 'small' ? 'medium' : '100%'}
+      gap={size !== 'small' ? 'small' : undefined}
+      {...rest}
+    />
+  );
+};

--- a/aries-site/src/examples/templates/page-layouts/HeaderOnlyExample.js
+++ b/aries-site/src/examples/templates/page-layouts/HeaderOnlyExample.js
@@ -1,0 +1,39 @@
+import React from 'react';
+import { Header, Box, Main, ResponsiveContext, Text } from 'grommet';
+
+export const HeaderOnlyExample = () => {
+  return (
+    <AppContainer>
+      <Box flex overflow="auto">
+        <Box height={{ min: '100%' }} gap="small">
+          <Header
+            fill="horizontal"
+            height="xxsmall"
+            background="green!"
+            pad="small"
+          >
+            <Text weight="bold" color="text-strong">
+              Header
+            </Text>
+          </Header>
+          <Main flex="grow" fill={undefined} background="orange" pad="small">
+            <Text weight="bold">Main</Text>
+          </Main>
+        </Box>
+      </Box>
+    </AppContainer>
+  );
+};
+
+const AppContainer = ({ ...rest }) => {
+  const size = React.useContext(ResponsiveContext);
+  return (
+    <Box
+      direction={size === 'small' ? 'column-reverse' : 'row'}
+      height={size === 'small' ? { max: 'large' } : '100%'}
+      width={size === 'small' ? 'medium' : '100%'}
+      gap={size !== 'small' ? 'small' : undefined}
+      {...rest}
+    />
+  );
+};

--- a/aries-site/src/examples/templates/page-layouts/SidebarHeaderExample.js
+++ b/aries-site/src/examples/templates/page-layouts/SidebarHeaderExample.js
@@ -1,0 +1,59 @@
+import React, { useContext } from 'react';
+import { Header, Box, Main, ResponsiveContext, Sidebar, Text } from 'grommet';
+
+export const SidebarHeaderExample = () => {
+  return (
+    <AppContainer>
+      <AppSidebar />
+      <Box flex overflow="auto">
+        <Box height={{ min: '100%' }} gap="small">
+          <Header
+            fill="horizontal"
+            height="xxsmall"
+            background="green!"
+            pad="small"
+          >
+            <Text weight="bold" color="text-strong">
+              Header
+            </Text>
+          </Header>
+          <Main flex="grow" fill={undefined} background="orange" pad="small">
+            <Text weight="bold">Main</Text>
+          </Main>
+        </Box>
+      </Box>
+    </AppContainer>
+  );
+};
+
+const AppSidebar = () => {
+  const size = useContext(ResponsiveContext);
+  return (
+    <Sidebar
+      /* Sidebar should switch from column to row orientation
+       * when on smaller screens */
+      direction={size !== 'small' ? 'column' : 'row'}
+      /* Min height is not needed in mobile contexts */
+      height={size !== 'small' ? { min: '100%' } : undefined}
+      background="blue!"
+      pad="small"
+    >
+      <Text weight="bold" color="text-strong">
+        Sidebar
+      </Text>
+    </Sidebar>
+  );
+};
+
+const AppContainer = ({ ...rest }) => {
+  const size = React.useContext(ResponsiveContext);
+  return (
+    <Box
+      direction={size === 'small' ? 'column-reverse' : 'row'}
+      height={size === 'small' ? { max: 'large' } : '100%'}
+      width={size === 'small' ? 'medium' : '100%'}
+      gap={size !== 'small' ? 'small' : undefined}
+      {...rest}
+    />
+  );
+};

--- a/aries-site/src/examples/templates/page-layouts/SidebarHeaderExample.js
+++ b/aries-site/src/examples/templates/page-layouts/SidebarHeaderExample.js
@@ -35,7 +35,7 @@ const AppSidebar = () => {
       direction={size !== 'small' ? 'column' : 'row'}
       /* Min height is not needed in mobile contexts */
       height={size !== 'small' ? { min: '100%' } : undefined}
-      background="blue!"
+      background={{ color: 'purple', dark: true }}
       pad="small"
     >
       <Text weight="bold" color="text-strong">

--- a/aries-site/src/examples/templates/page-layouts/SidebarHeaderFooterExample.js
+++ b/aries-site/src/examples/templates/page-layouts/SidebarHeaderFooterExample.js
@@ -51,7 +51,7 @@ const AppSidebar = () => {
       direction={size !== 'small' ? 'column' : 'row'}
       /* Min height is not needed in mobile contexts */
       height={size !== 'small' ? { min: '100%' } : undefined}
-      background="blue!"
+      background={{ color: 'purple', dark: true }}
       pad="small"
     >
       <Text weight="bold" color="text-strong">

--- a/aries-site/src/examples/templates/page-layouts/SidebarHeaderFooterExample.js
+++ b/aries-site/src/examples/templates/page-layouts/SidebarHeaderFooterExample.js
@@ -1,0 +1,75 @@
+import React, { useContext } from 'react';
+import {
+  Header,
+  Box,
+  Footer,
+  Main,
+  ResponsiveContext,
+  Sidebar,
+  Text,
+} from 'grommet';
+
+export const SidebarHeaderFooterExample = () => {
+  return (
+    <AppContainer>
+      <AppSidebar />
+      <Box flex overflow="auto">
+        <Box height={{ min: '100%' }} gap="small">
+          <Header
+            fill="horizontal"
+            height="xxsmall"
+            background="green!"
+            pad="small"
+          >
+            <Text weight="bold" color="text-strong">
+              Header
+            </Text>
+          </Header>
+          <Main flex="grow" fill={undefined} background="orange" pad="small">
+            <Text weight="bold">Main</Text>
+          </Main>
+          <Footer
+            fill="horizontal"
+            height="xxsmall"
+            background="blue"
+            pad="small"
+          >
+            <Text weight="bold">Footer</Text>
+          </Footer>
+        </Box>
+      </Box>
+    </AppContainer>
+  );
+};
+
+const AppSidebar = () => {
+  const size = useContext(ResponsiveContext);
+  return (
+    <Sidebar
+      /* Sidebar should switch from column to row orientation
+       * when on smaller screens */
+      direction={size !== 'small' ? 'column' : 'row'}
+      /* Min height is not needed in mobile contexts */
+      height={size !== 'small' ? { min: '100%' } : undefined}
+      background="blue!"
+      pad="small"
+    >
+      <Text weight="bold" color="text-strong">
+        Sidebar
+      </Text>
+    </Sidebar>
+  );
+};
+
+const AppContainer = ({ ...rest }) => {
+  const size = React.useContext(ResponsiveContext);
+  return (
+    <Box
+      direction={size === 'small' ? 'column-reverse' : 'row'}
+      height={size === 'small' ? { max: 'large' } : '100%'}
+      width={size === 'small' ? 'medium' : '100%'}
+      gap={size !== 'small' ? 'small' : undefined}
+      {...rest}
+    />
+  );
+};

--- a/aries-site/src/examples/templates/page-layouts/index.js
+++ b/aries-site/src/examples/templates/page-layouts/index.js
@@ -1,0 +1,4 @@
+export * from './SidebarHeaderFooterExample';
+export * from './SidebarHeaderExample';
+export * from './HeaderFooterExample';
+export * from './HeaderOnlyExample';

--- a/aries-site/src/layouts/content/Subsection.js
+++ b/aries-site/src/layouts/content/Subsection.js
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types';
 import { Anchor, Box, Button, Header, Text } from 'grommet';
 import { Link as LinkIcon } from 'grommet-icons';
 import { Subheading } from '../../components';
-import { getPageDetails } from '../../utils';
+import { getPageDetails, formatName } from '../../utils';
 
 // Text size should be based on if its parent heading is an
 // h2, h3, etc.
@@ -32,10 +32,7 @@ export const Subsection = ({
   const [over, setOver] = useState(false);
   const parent = getPageDetails(topic);
 
-  const id = name
-    .split(' ')
-    .join('-')
-    .toLowerCase();
+  const id = formatName(name);
 
   const firstChild = React.Children.map(children, (child, index) => {
     if (index === 0) {
@@ -81,38 +78,41 @@ export const Subsection = ({
        * removes that extra space.
        */}
       <Box gap={level !== 3 ? 'small' : undefined}>
-        {showHeading && (
-          <Header>
-            <Box align="start" gap="small">
-              {level === 1 && topic && (
-                <Link href={`/${topic.toLowerCase()}`} passHref>
-                  <Button
-                    label={<Text color="text">{parent.name}</Text>}
-                    icon={parent.icon('small', parent.color)}
-                    plain
-                    {...rest}
-                  />
-                </Link>
+        {
+          showHeading && (
+            <Header>
+              <Box align="start" gap="small">
+                {level === 1 && topic && (
+                  <Link href={`/${topic.toLowerCase()}`} passHref>
+                    <Button
+                      label={<Text color="text">{parent.name}</Text>}
+                      icon={parent.icon('small', parent.color)}
+                      plain
+                      {...rest}
+                    />
+                  </Link>
+                )}
+                <Subheading
+                  level={level}
+                  headingSize={headingSize || HEADING_SIZE[level]}
+                >
+                  {name}
+                </Subheading>
+              </Box>
+              {level > 1 && (
+                <Anchor
+                  a11yTitle={`Jump to section titled ${name}`}
+                  href={`#${id}`}
+                  icon={
+                    <LinkIcon color={over ? 'text-xweak' : 'transparent'} />
+                  }
+                />
               )}
-              <Subheading
-                level={level}
-                headingSize={headingSize || HEADING_SIZE[level]}
-              >
-                {name}
-              </Subheading>
-            </Box>
-            {level > 1 && (
-              <Anchor
-                a11yTitle={`Jump to section titled ${name}`}
-                href={`#${id}`}
-                icon={<LinkIcon color={over ? 'text-xweak' : 'transparent'} />}
-              />
-            )}
-          </Header>
-        )
-        /* Isolates the first child to ensure the gap between heading and
-         * first child is correct size. See comment on line 33 for reasoning.
-         */
+            </Header>
+          )
+          /* Isolates the first child to ensure the gap between heading and
+           * first child is correct size. See comment on line 33 for reasoning.
+           */
         }
         {firstChild}
       </Box>

--- a/aries-site/src/pages/templates/page-layouts.js
+++ b/aries-site/src/pages/templates/page-layouts.js
@@ -1,12 +1,22 @@
 import React from 'react';
-
-import { ComingSoon, Meta } from '../../components';
-import { ContentSection, Layout, Subsection } from '../../layouts';
+import Link from 'next/link';
+import { Anchor } from 'grommet';
+import { CardGrid, Meta, SubsectionText, BulletedList } from '../../components';
+import {
+  HeaderOnlyExample,
+  HeaderFooterExample,
+  SidebarHeaderExample,
+  SidebarHeaderFooterExample,
+} from '../../examples';
+import { ContentSection, Example, Layout, Subsection } from '../../layouts';
 import { getPageDetails } from '../../utils';
 
 const title = 'Page Layouts';
 const topic = 'Templates';
 const pageDetails = getPageDetails(title);
+
+const getRelatedCards = names =>
+  names.sort().map(pattern => getPageDetails(pattern));
 
 const PageLayouts = () => {
   return (
@@ -17,9 +27,121 @@ const PageLayouts = () => {
         canonicalUrl="https://design-system.hpe.design/templates/page-layouts"
       />
       <ContentSection>
-        <Subsection name={title} level={1} topic={topic} />
+        <Subsection name={title} level={1} topic={topic}>
+          <SubsectionText>{pageDetails.description}</SubsectionText>
+          <SubsectionText>
+            Depending on the context or purpose of an application, the page
+            structure may vary. The following are common and recommended page
+            layouts:
+          </SubsectionText>
+          <SubsectionText>
+            <BulletedList
+              items={[
+                <Link href="#sidebar-header-and-footer" passHref>
+                  <Anchor label="Page with sidebar, header, and footer" />
+                </Link>,
+                <Link href="#sidebar-and-header" passHref>
+                  <Anchor label="Page with sidebar and header" />
+                </Link>,
+                <Link href="#header-and-footer" passHref>
+                  <Anchor label="Page with header and footer" />
+                </Link>,
+                <Link href="#header-only" passHref>
+                  <Anchor label="Page with header only" />
+                </Link>,
+              ]}
+            />
+          </SubsectionText>
+        </Subsection>
       </ContentSection>
-      <ComingSoon />
+      <ContentSection>
+        <Subsection name="Sidebar, header, and footer">
+          <SubsectionText>
+            Photo booth la croix tofu mumblecore vaporware edison bulb leggings
+            affogato schlitz readymade polaroid air plant farm-to-table
+            adaptogen stumptown.
+          </SubsectionText>
+          <Example
+            code="https://raw.githubusercontent.com/hpe-design/design-system/master/aries-site/src/examples/templates/page-layouts/SidebarHeaderFooterExample.js"
+            width="100%"
+            template
+          >
+            <SidebarHeaderFooterExample />
+          </Example>
+        </Subsection>
+        <Subsection name="Relevant components" level={3}>
+          <SubsectionText>
+            For guidance on how to place components within these content areas,
+            see the examples on these pages.
+          </SubsectionText>
+          <CardGrid
+            cards={getRelatedCards(['Global Sidebar', 'Header', 'Footer'])}
+          />
+        </Subsection>
+        <Subsection name="Sidebar and header">
+          <SubsectionText>
+            Photo booth la croix tofu mumblecore vaporware edison bulb leggings
+            affogato schlitz readymade polaroid air plant farm-to-table
+            adaptogen stumptown.
+          </SubsectionText>
+          <Example
+            code="https://raw.githubusercontent.com/hpe-design/design-system/master/aries-site/src/examples/templates/page-layouts/SidebarHeaderExample.js"
+            width="100%"
+            template
+          >
+            <SidebarHeaderExample />
+          </Example>
+        </Subsection>
+        <Subsection name="Relevant components" level={3}>
+          <SubsectionText>
+            For guidance on how to place components within these content areas,
+            see the examples on these pages.
+          </SubsectionText>
+          <CardGrid cards={getRelatedCards(['Global Sidebar', 'Header'])} />
+        </Subsection>
+        <Subsection name="Header and footer">
+          <SubsectionText>
+            Photo booth la croix tofu mumblecore vaporware edison bulb leggings
+            affogato schlitz readymade polaroid air plant farm-to-table
+            adaptogen stumptown.
+          </SubsectionText>
+          <Example
+            code="https://raw.githubusercontent.com/hpe-design/design-system/master/aries-site/src/examples/templates/page-layouts/HeaderFooterExample.js"
+            width="100%"
+            template
+          >
+            <HeaderFooterExample />
+          </Example>
+        </Subsection>
+        <Subsection name="Relevant components" level={3}>
+          <SubsectionText>
+            For guidance on how to place components within these content areas,
+            see the examples on these pages.
+          </SubsectionText>
+          <CardGrid cards={getRelatedCards(['Header', 'Footer'])} />
+        </Subsection>
+        <Subsection name="Header only">
+          <SubsectionText>
+            Photo booth la croix tofu mumblecore vaporware edison bulb leggings
+            affogato schlitz readymade polaroid air plant farm-to-table
+            adaptogen stumptown.
+          </SubsectionText>
+          <Example
+            code="https://raw.githubusercontent.com/hpe-design/design-system/master/aries-site/src/examples/templates/page-layouts/HeaderOnlyExample.js"
+            width="100%"
+            template
+          >
+            <HeaderOnlyExample />
+          </Example>
+        </Subsection>
+        <Subsection name="Relevant components" level={3}>
+          <SubsectionText>
+            For guidance on how to place components within these content areas,
+            see the examples on these pages.
+          </SubsectionText>
+          <CardGrid cards={getRelatedCards(['Header'])} />
+        </Subsection>
+      </ContentSection>
     </Layout>
   );
 };

--- a/aries-site/src/utils/search.js
+++ b/aries-site/src/utils/search.js
@@ -8,8 +8,24 @@ const allPageSections = structure
 
 export const getSearchSuggestions = allPages.concat(allPageSections).sort();
 
+// String to slug from https://gist.github.com/hagemann/382adfc57adbd5af078dc93feef01fe1#file-slugify-js
 export const formatName = name => {
-  return name.split(' ').join('-').toLowerCase();
+  const a = `àáâäæãåāăąçćčđďèéêëēėęěğǵḧîïíīįìłḿñńǹňôöòóœøōõőṕŕřßśšşșťțûüùúūǘůűų
+  ẃẍÿýžźż·/_,:;`;
+  const b = `aaaaaaaaaacccddeeeeeeeegghiiiiiilmnnnnoooooooooprrsssssttuuuuuuuuu
+  wxyyzzz------`;
+  const p = new RegExp(a.split('').join('|'), 'g');
+
+  return name
+    .toString()
+    .toLowerCase()
+    .replace(/\s+/g, '-') // Replace spaces with -
+    .replace(p, c => b.charAt(a.indexOf(c))) // Replace special characters
+    .replace(/&/g, '-and-') // Replace & with 'and'
+    .replace(/[^\w-]+/g, '') // Remove all non-word characters
+    .replace(/--+/g, '-') // Replace multiple - with single -
+    .replace(/^-+/, '') // Trim - from start of text
+    .replace(/-+$/, ''); // Trim - from end of text
 };
 
 export const getPageDetails = pageName =>


### PR DESCRIPTION
This deploy is scheduled to be discussed on Thursday's meeting, but any feedback prior is welcomed!

Preview: https://deploy-preview-907--keen-mayer-a86c8b.netlify.app/templates/page-layouts

This takes discussions from last week's meetings and implements them as a first pass at a Page Layouts page. It seemed the conclusion from the meeting was that Page Layouts would be more coarse/high-level demonstration of how content areas layout on a page, but that content-rich examples would be housed on separate template pages.

After a follow-up call with Maggie and Vicky, we decided to focus on 4 variations from [this Figma file](https://www.figma.com/file/aGU4dgPXgnxuSKkoxPU8x4/Page-layout?node-id=0%3A1). If other layouts feel necessary, please provide feedback of which should be added.
This PR implements the high-level content areas and links to the relevant component pages (each containing rich examples of how components could will these layout areas). Once full-page templates have been created we can add them in.

TBD: How do we want to present scrolling? Do we want to show examples with sticky headers? etc.