### PR TITLE
Proposal - Add edit this page button for docs

### DIFF
--- a/aries-site/src/layouts/content/DocsPageHeader.js
+++ b/aries-site/src/layouts/content/DocsPageHeader.js
@@ -9,7 +9,7 @@ export const DocsPageHeader = ({ title, topic }) => {
   const page = getPageDetails(title);
 
   return (
-    <Subsection name={title} topic={topic} level={1}>
+    <Subsection name={title} topic={topic} level={1} showEditButton>
       <Box>
         <SubsectionText>{page.description}</SubsectionText>
         {page.status && <Status status={page.status} />}

--- a/aries-site/src/layouts/content/Subsection.js
+++ b/aries-site/src/layouts/content/Subsection.js
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import Link from 'next/link';
+import { useRouter } from 'next/router';
 import PropTypes from 'prop-types';
 import { Anchor, Box, Button, Header, Text } from 'grommet';
 import { Link as LinkIcon } from 'grommet-icons';
@@ -26,12 +27,14 @@ export const Subsection = ({
   headingSize,
   level,
   name,
+  showEditButton,
   topic,
   ...rest
 }) => {
   const [over, setOver] = useState(false);
   const parent = topic && getPageDetails(topic);
-
+  const router = useRouter();
+  console.log(router);
   const id = formatName(name);
 
   const firstChild = React.Children.map(children, (child, index) => {
@@ -108,6 +111,15 @@ export const Subsection = ({
                   }
                 />
               )}
+              {showEditButton && (
+                <Button
+                  alignSelf="start"
+                  href={`https://github.com/hpe-design/design-system/tree/master/aries-site/src/pages${router.pathname}.mdx`}
+                  label="Edit this page"
+                  rel="noopener"
+                  target="_blank"
+                />
+              )}
             </Header>
           )
           /* Isolates the first child to ensure the gap between heading and
@@ -128,6 +140,7 @@ Subsection.propTypes = {
   headingSize: PropTypes.string,
   name: PropTypes.string.isRequired,
   showHeading: PropTypes.bool,
+  showEditButton: PropTypes.bool,
   topic: PropTypes.string,
 };
 
@@ -137,5 +150,6 @@ Subsection.defaultProps = {
   gap: 'medium',
   headingSize: undefined,
   showHeading: true,
+  showEditButton: false,
   topic: undefined,
 };


### PR DESCRIPTION
Adds a button to the top of the docs pages to allow quick access to editing the MDX file in github. This will open the appropriate MDX file in a new window, allowing the user to create edits and open a PR with the proposed changes.

Modeling after approach seen on other docs sites. Open to any design feedback, but I think have this there creates a collaborative feel. It makes it easier for our team members to update copy and potentially creates a place for non-team members to propose fixes to gaps in our documentation that we might not have seen.

