### PR TITLE
add password validation

### DIFF
--- a/aries-site/src/examples/templates/forms/SignUpExample.js
+++ b/aries-site/src/examples/templates/forms/SignUpExample.js
@@ -4,6 +4,7 @@ import {
   Box,
   Button,
   CheckBox,
+  List,
   Form,
   FormField,
   Header,
@@ -12,6 +13,7 @@ import {
   Text,
   TextInput,
 } from 'grommet';
+import { FormCheckmark, FormClose } from 'grommet-icons';
 
 const emailValidation = [
   {
@@ -34,27 +36,22 @@ const emailValidation = [
 const passwordRulesStrong = [
   {
     regexp: new RegExp('(?=.*?[A-Z])'),
-    message: 'At least one uppercase English letter',
+    message: 'One uppercase letter',
     status: 'error',
   },
   {
     regexp: new RegExp('(?=.*?[a-z])'),
-    message: 'At least one lowercase English letter',
-    status: 'error',
-  },
-  {
-    regexp: new RegExp('(?=.*?[0-9])'),
-    message: 'At least one number',
+    message: 'One lowercase letter',
     status: 'error',
   },
   {
     regexp: new RegExp('(?=.*?[#?!@$ %^&*-])'),
-    message: 'At least one special character or space',
+    message: 'One special character',
     status: 'error',
   },
   {
     regexp: new RegExp('.{8,}'),
-    message: 'At least eight characters',
+    message: 'At least 8 characters',
     status: 'error',
   },
 ];
@@ -88,6 +85,18 @@ export const SignUpExample = () => {
   const [formValues, setFormValues] = React.useState({
     email: 'jane.smith@hpe.com',
   });
+  const [passwordRules, setPasswordRules] = React.useState(passwordRulesStrong);
+
+  const onChange = values => {
+    setFormValues(values);
+    const adjustedPasswordRules = passwordRules.map(rule => {
+      const adjustedRule = { ...rule };
+      const valid = adjustedRule.regexp.test(values.password);
+      adjustedRule.valid = valid;
+      return adjustedRule;
+    });
+    setPasswordRules(adjustedPasswordRules);
+  };
 
   // eslint-disable-next-line no-unused-vars
   const onSubmit = ({ value, touched }) => {
@@ -114,8 +123,8 @@ export const SignUpExample = () => {
         >
           <Form
             validate="blur"
+            onChange={nextValue => onChange(nextValue)}
             value={formValues}
-            onChange={setFormValues}
             onSubmit={({ value, touched }) => onSubmit({ value, touched })}
           >
             <FormField
@@ -147,9 +156,36 @@ export const SignUpExample = () => {
               label="Password"
               htmlFor="password-sign-up"
               name="password"
-              help="Include at least 8 characters, a lowercase letter, an
-              uppercase letter, a number, and a special character"
-              validate={passwordRulesStrong}
+              info={
+                <List
+                  data={passwordRules}
+                  border={{ color: 'none' }}
+                  pad="none"
+                >
+                  {rule => {
+                    if (
+                      formValues.password === undefined ||
+                      formValues.password.length === 0
+                    ) {
+                      return (
+                        <Box direction="row" gap="xsmall">
+                          <Text>{rule.message}</Text>
+                        </Box>
+                      );
+                    }
+                    return (
+                      <Box direction="row" gap="xsmall">
+                        {formValues.password && rule.valid ? (
+                          <FormCheckmark />
+                        ) : (
+                          <FormClose />
+                        )}
+                        <Text>{rule.message}</Text>
+                      </Box>
+                    );
+                  }}
+                </List>
+              }
             >
               <TextInput
                 id="password-sign-up"

--- a/aries-site/src/examples/templates/forms/SignUpExample.js
+++ b/aries-site/src/examples/templates/forms/SignUpExample.js
@@ -176,9 +176,13 @@ export const SignUpExample = () => {
                     return (
                       <Box direction="row" gap="xsmall">
                         {formValues.password && rule.valid ? (
-                          <FormCheckmark />
+                          <Box alignSelf="center">
+                            <FormCheckmark size="small" />
+                          </Box>
                         ) : (
-                          <FormClose />
+                          <Box alignSelf="center">
+                            <FormClose size="small" />
+                          </Box>
                         )}
                         <Text>{rule.message}</Text>
                       </Box>

--- a/aries-site/src/examples/templates/forms/SimpleSignUpExample.js
+++ b/aries-site/src/examples/templates/forms/SimpleSignUpExample.js
@@ -176,9 +176,13 @@ export const SimpleSignUpExample = () => {
                     return (
                       <Box direction="row" gap="xsmall">
                         {formValues.password && rule.valid ? (
-                          <FormCheckmark />
+                          <Box alignSelf="center">
+                            <FormCheckmark size="small" />
+                          </Box>
                         ) : (
-                          <FormClose />
+                          <Box alignSelf="center">
+                            <FormClose size="small" />
+                          </Box>
                         )}
                         <Text>{rule.message}</Text>
                       </Box>

--- a/aries-site/src/examples/templates/forms/SimpleSignUpExample.js
+++ b/aries-site/src/examples/templates/forms/SimpleSignUpExample.js
@@ -4,6 +4,7 @@ import {
   Box,
   Button,
   CheckBox,
+  List,
   Form,
   FormField,
   Header,
@@ -12,31 +13,27 @@ import {
   Text,
   TextInput,
 } from 'grommet';
+import { FormCheckmark, FormClose } from 'grommet-icons';
 
 const passwordRulesStrong = [
   {
     regexp: new RegExp('(?=.*?[A-Z])'),
-    message: 'At least one uppercase English letter',
+    message: 'One uppercase letter',
     status: 'error',
   },
   {
     regexp: new RegExp('(?=.*?[a-z])'),
-    message: 'At least one lowercase English letter',
-    status: 'error',
-  },
-  {
-    regexp: new RegExp('(?=.*?[0-9])'),
-    message: 'At least one number',
+    message: 'One lowercase letter',
     status: 'error',
   },
   {
     regexp: new RegExp('(?=.*?[#?!@$ %^&*-])'),
-    message: 'At least one special character or space',
+    message: 'One special character',
     status: 'error',
   },
   {
     regexp: new RegExp('.{8,}'),
-    message: 'At least eight characters',
+    message: 'At least 8 characters',
     status: 'error',
   },
 ];
@@ -88,6 +85,18 @@ export const SimpleSignUpExample = () => {
   const [formValues, setFormValues] = React.useState({
     email: 'jane.smith@hpe.com',
   });
+  const [passwordRules, setPasswordRules] = React.useState(passwordRulesStrong);
+
+  const onChange = values => {
+    setFormValues(values);
+    const adjustedPasswordRules = passwordRules.map(rule => {
+      const adjustedRule = { ...rule };
+      const valid = adjustedRule.regexp.test(values.password);
+      adjustedRule.valid = valid;
+      return adjustedRule;
+    });
+    setPasswordRules(adjustedPasswordRules);
+  };
 
   // eslint-disable-next-line no-unused-vars
   const onSubmit = ({ value, touched }) => {
@@ -115,7 +124,7 @@ export const SimpleSignUpExample = () => {
           <Form
             validate="blur"
             value={formValues}
-            onChange={setFormValues}
+            onChange={nextValue => onChange(nextValue)}
             onSubmit={({ value, touched }) => onSubmit({ value, touched })}
           >
             <FormField
@@ -147,7 +156,36 @@ export const SimpleSignUpExample = () => {
               label="Password"
               htmlFor="password-sign-up-simple"
               name="password"
-              validate={passwordRulesStrong}
+              info={
+                <List
+                  data={passwordRules}
+                  border={{ color: 'none' }}
+                  pad="none"
+                >
+                  {rule => {
+                    if (
+                      formValues.password === undefined ||
+                      formValues.password.length === 0
+                    ) {
+                      return (
+                        <Box direction="row" gap="xsmall">
+                          <Text>{rule.message}</Text>
+                        </Box>
+                      );
+                    }
+                    return (
+                      <Box direction="row" gap="xsmall">
+                        {formValues.password && rule.valid ? (
+                          <FormCheckmark />
+                        ) : (
+                          <FormClose />
+                        )}
+                        <Text>{rule.message}</Text>
+                      </Box>
+                    );
+                  }}
+                </List>
+              }
             >
               <TextInput
                 id="password-sign-up-simple"


### PR DESCRIPTION
## Work Completed 

[Preview](https://deploy-preview-983--keen-mayer-a86c8b.netlify.app/templates/forms)
[figma](https://www.figma.com/file/3fkwBelW5UsCbfwdDCJkT8/HPE-Form-Templates?node-id=0%3A1)

- Added password validation to match designs and new validation flow 
- Added this to both SignUp examples in form page

## To Do 

Greg is going to create a icon which will be used instead of `formclose` so once this icon is ready I will switch them out 
