### PR TITLE
add scroll example for checkbox group

### DIFF
--- a/aries-site/src/examples/components/checkboxgroup/CheckBoxGroupScrollExample.js
+++ b/aries-site/src/examples/components/checkboxgroup/CheckBoxGroupScrollExample.js
@@ -1,0 +1,26 @@
+import React from 'react';
+import { Box, CheckBoxGroup, Form, FormField } from 'grommet';
+
+export const CheckBoxGroupScrollExample = () => {
+  return (
+    <Form>
+      <FormField name="scroll-checkbox" label="Label" htmlFor="scroll-checkbox">
+        <Box width="medium" overflow="scroll" height="small">
+          <CheckBoxGroup
+            name="scroll-checkbox"
+            id="scroll-checkbox"
+            options={[
+              'Option 1',
+              'Option 2',
+              'Option 3',
+              'Option4',
+              'Option5',
+              'Option6',
+              'Option7',
+            ]}
+          />
+        </Box>
+      </FormField>
+    </Form>
+  );
+};

--- a/aries-site/src/examples/components/checkboxgroup/CheckBoxGroupScrollExample.js
+++ b/aries-site/src/examples/components/checkboxgroup/CheckBoxGroupScrollExample.js
@@ -4,7 +4,12 @@ import { Box, CheckBoxGroup, Form, FormField } from 'grommet';
 export const CheckBoxGroupScrollExample = () => {
   return (
     <Form>
-      <FormField name="scroll-checkbox" label="Label" htmlFor="scroll-checkbox">
+      <FormField
+        pad="xsmall"
+        name="scroll-checkbox"
+        label="Label"
+        htmlFor="scroll-checkbox"
+      >
         <Box width="medium" overflow="scroll" height="small">
           <CheckBoxGroup
             name="scroll-checkbox"

--- a/aries-site/src/examples/components/checkboxgroup/index.js
+++ b/aries-site/src/examples/components/checkboxgroup/index.js
@@ -1,4 +1,5 @@
 export * from './CheckBoxGroupDescriptionExample';
+export * from './CheckBoxGroupScrollExample';
 export * from './CheckBoxGroupDisabledExample';
 export * from './CheckBoxGroupObjectExample';
 export * from './CheckBoxGroupSimpleExample';

--- a/aries-site/src/pages/components/checkboxgroup.mdx
+++ b/aries-site/src/pages/components/checkboxgroup.mdx
@@ -4,6 +4,7 @@ import {
   CheckBoxGroupDescriptionExample,
   CheckBoxGroupObjectExample,
   CheckBoxGroupSimpleExample,
+  CheckBoxGroupScrollExample,
   CheckBoxGroupValidationExample,
 } from '../../examples/components/checkboxgroup';
 
@@ -96,4 +97,14 @@ Used to indicate that CheckBoxGroup cannot be interacted with.
   height={{ min: 'small' }}
 >
   <CheckBoxGroupDisabledExample />
+</Example>
+
+### Scroll
+
+<Example
+  docs="https://v2.grommet.io/checkboxgroup?theme=hpe#props"
+  code="https://raw.githubusercontent.com/hpe-design/design-system/master/aries-site/src/examples/components/checkboxgroup/CheckBoxGroupDescriptionExample.js"
+  height={{ min: 'small' }}
+>
+  <CheckBoxGroupScrollExample />
 </Example>

--- a/aries-site/src/pages/components/checkboxgroup.mdx
+++ b/aries-site/src/pages/components/checkboxgroup.mdx
@@ -101,6 +101,8 @@ Used to indicate that CheckBoxGroup cannot be interacted with.
 
 ### Scroll
 
+When many options are available and vertical space is limited, a scrollable checkbox group may be considered.
+
 <Example
   docs="https://v2.grommet.io/checkboxgroup?theme=hpe#props"
   code="https://raw.githubusercontent.com/hpe-design/design-system/master/aries-site/src/examples/components/checkboxgroup/CheckBoxGroupDescriptionExample.js"


### PR DESCRIPTION
## WIP

I made this preview up for Greg to review to make sure this is what he had in mind

closes #991 

## work completed 

There was a request to show how `checkboxgroup` can be shown within a scroll. If you have a long list of `checkboxs` 

## to do 

I need to add some context behind when to use this type.