### PR TITLE
Forms: Change Heading to Text and update password placeholder

### DIFF
--- a/aries-site/src/examples/templates/forms/ChangePasswordExample.js
+++ b/aries-site/src/examples/templates/forms/ChangePasswordExample.js
@@ -1,13 +1,5 @@
 import React from 'react';
-import {
-  Box,
-  Button,
-  Form,
-  FormField,
-  Header,
-  Heading,
-  TextInput,
-} from 'grommet';
+import { Box, Button, Form, FormField, Header, Text, TextInput } from 'grommet';
 
 const passwordRulesWeak = [
   {
@@ -25,18 +17,13 @@ const passwordRulesWeak = [
 const FormContainer = ({ ...rest }) => {
   return (
     <Box background="background-front" border round="small" overflow="hidden">
-      <Box
-        flex
-        pad={{ horizontal: 'medium', vertical: 'medium' }}
-        {...rest}
-       />
+      <Box flex pad={{ horizontal: 'medium', vertical: 'medium' }} {...rest} />
     </Box>
   );
 };
 
 export const ChangePasswordExample = () => {
   const [formValues, setFormValues] = React.useState({});
-  const [readyToSubmit, setReadyToSubmit] = React.useState(false);
 
   // eslint-disable-next-line no-unused-vars
   const onSubmit = ({ value, touched }) => {
@@ -45,7 +32,6 @@ export const ChangePasswordExample = () => {
 
   const confirmPassword = () => {
     const doesMatch = formValues.newPassword === formValues.confirmPassword;
-    setReadyToSubmit(doesMatch);
     return doesMatch
       ? undefined
       : { message: 'Passwords do not match', status: 'error' };
@@ -60,9 +46,9 @@ export const ChangePasswordExample = () => {
           gap="xxsmall"
           pad={{ horizontal: 'xxsmall' }}
         >
-          <Heading level={3} margin="none">
+          <Text size="xxlarge" weight="bold">
             Change Password
-          </Heading>
+          </Text>
         </Header>
         <Box
           // Padding used to prevent focus from being cutoff
@@ -82,7 +68,7 @@ export const ChangePasswordExample = () => {
               <TextInput
                 id="currentPassword"
                 name="currentPassword"
-                placeholder="•••••••••••••••"
+                placeholder="Current password"
                 type="password"
               />
             </FormField>
@@ -90,15 +76,12 @@ export const ChangePasswordExample = () => {
               htmlFor="newPassword"
               name="newPassword"
               label="New Password"
-              help={`Include ${passwordRulesWeak.map(rule => {
-                return ` ${rule.message.toLowerCase()}`;
-              })}`}
               validate={passwordRulesWeak}
             >
               <TextInput
                 id="newPassword"
                 name="newPassword"
-                placeholder="•••••••••••••••"
+                placeholder="Enter new password"
                 type="password"
               />
             </FormField>
@@ -111,17 +94,12 @@ export const ChangePasswordExample = () => {
               <TextInput
                 id="confirmPassword"
                 name="confirmPassword"
-                placeholder="•••••••••••••••"
+                placeholder="Confirm new password"
                 type="password"
               />
             </FormField>
             <Box align="start" margin={{ top: 'medium', bottom: 'small' }}>
-              <Button
-                label="Update Password"
-                primary
-                type="submit"
-                disabled={!readyToSubmit}
-              />
+              <Button label="Update Password" primary type="submit" />
             </Box>
           </Form>
         </Box>

--- a/aries-site/src/examples/templates/forms/CustomizeExample.js
+++ b/aries-site/src/examples/templates/forms/CustomizeExample.js
@@ -6,7 +6,6 @@ import {
   Form,
   FormField,
   Header,
-  Heading,
   RadioButtonGroup,
   Text,
 } from 'grommet';
@@ -36,9 +35,9 @@ export const CustomizeExample = () => {
           gap="xxsmall"
           pad={{ horizontal: 'xxsmall' }}
         >
-          <Heading level={3} margin="none">
+          <Text size="xxlarge" weight="bold">
             Customize
-          </Heading>
+          </Text>
           <Text>your HPE Edgeline Server </Text>
         </Header>
         <Box
@@ -53,9 +52,9 @@ export const CustomizeExample = () => {
           >
             <FormField
               label={
-                <Heading level={4} margin="none">
+                <Text size="large" weight="bold">
                   Memory
-                </Heading>
+                </Text>
               }
               help={
                 <Anchor href="#" size="xsmall">
@@ -76,9 +75,9 @@ export const CustomizeExample = () => {
             </FormField>
             <FormField
               label={
-                <Heading level={4} margin="none">
+                <Text size="large" weight="bold">
                   CPU
-                </Heading>
+                </Text>
               }
               help={
                 <Anchor href="#" size="xsmall">

--- a/aries-site/src/examples/templates/forms/FilterExample.js
+++ b/aries-site/src/examples/templates/forms/FilterExample.js
@@ -5,8 +5,8 @@ import {
   Form,
   FormField,
   Header,
-  Heading,
   Select,
+  Text,
   TextInput,
 } from 'grommet';
 
@@ -64,9 +64,9 @@ export const FilterExample = () => {
           gap="xxsmall"
           pad={{ horizontal: 'xxsmall' }}
         >
-          <Heading level={3} margin="none">
+          <Text size="xxlarge" weight="bold">
             Filter
-          </Heading>
+          </Text>
         </Header>
         <Box
           // Padding used to prevent focus from being cutoff

--- a/aries-site/src/examples/templates/forms/PayExample.js
+++ b/aries-site/src/examples/templates/forms/PayExample.js
@@ -7,7 +7,6 @@ import {
   FormField,
   MaskedInput,
   Header,
-  Heading,
   Text,
   TextInput,
 } from 'grommet';
@@ -121,9 +120,9 @@ export const PayExample = () => {
           gap="xxsmall"
           pad={{ horizontal: 'xxsmall' }}
         >
-          <Heading level={3} margin="none">
+          <Text size="xxlarge" weight="bold">
             Pay
-          </Heading>
+          </Text>
           <Text>for your HPE products</Text>
         </Header>
         <Box
@@ -152,9 +151,9 @@ export const PayExample = () => {
             <Box margin="small" align="center">
               <Text color="text-xweak">or</Text>
             </Box>
-            <Heading level={4} margin={{ bottom: 'small', top: 'none' }}>
+            <Text size="large" margin={{ bottom: 'small', top: 'none' }}>
               Credit Card Information
-            </Heading>
+            </Text>
             <RequiredFormField
               name="cardName"
               required

--- a/aries-site/src/examples/templates/forms/SettingsExample.js
+++ b/aries-site/src/examples/templates/forms/SettingsExample.js
@@ -6,7 +6,6 @@ import {
   Form,
   FormField,
   Header,
-  Heading,
   RangeInput,
   Text,
   TextInput,
@@ -15,11 +14,7 @@ import {
 const FormContainer = ({ ...rest }) => {
   return (
     <Box background="background-front" border round="small" overflow="hidden">
-      <Box
-        flex
-        pad={{ horizontal: 'medium', vertical: 'medium' }}
-        {...rest}
-       />
+      <Box flex pad={{ horizontal: 'medium', vertical: 'medium' }} {...rest} />
     </Box>
   );
 };
@@ -45,9 +40,9 @@ export const SettingsExample = () => {
           gap="xxsmall"
           pad={{ horizontal: 'xxsmall' }}
         >
-          <Heading level={3} margin="none">
+          <Text size="xxlarge" weight="bold">
             Settings
-          </Heading>
+          </Text>
           <Text>for HPE Service</Text>
         </Header>
         <Box

--- a/aries-site/src/examples/templates/forms/ShippingExample.js
+++ b/aries-site/src/examples/templates/forms/ShippingExample.js
@@ -7,7 +7,6 @@ import {
   Form,
   FormField,
   Header,
-  Heading,
   MaskedInput,
   Select,
   Text,
@@ -165,9 +164,9 @@ export const ShippingExample = () => {
           gap="xxsmall"
           pad={{ horizontal: 'xxsmall' }}
         >
-          <Heading level={3} margin="none">
+          <Text size="xxlarge" weight="bold">
             Shipping
-          </Heading>
+          </Text>
           <Text>for your HPE products</Text>
         </Header>
         <Box
@@ -184,10 +183,13 @@ export const ShippingExample = () => {
             onSubmit={({ value, touched }) => onSubmit({ value, touched })}
           >
             <Box>
-              <Heading level={4} margin={{ bottom: 'small', top: 'none' }}>
+              <Text size="large" margin={{ bottom: 'xsmall', top: 'none' }}>
                 Shipping Information
-              </Heading>
-              <Text margin={{ horizontal: 'small', vertical: 'xsmall' }}>
+              </Text>
+              <Text
+                margin={{ horizontal: 'none', vertical: 'xsmall' }}
+                size="xsmall"
+              >
                 Shipping Address *
               </Text>
               <FormField required htmlFor="firstName" name="firstName">
@@ -238,9 +240,9 @@ export const ShippingExample = () => {
               </FormField>
             </Box>
             <Box>
-              <Heading level={4} margin={{ bottom: 'small' }}>
+              <Text size="large" margin={{ vertical: 'small' }}>
                 Contact Information
-              </Heading>
+              </Text>
               <FormField htmlFor="phone-ship" name="phone" label="Phone Number">
                 <MaskedInput id="phone-ship" name="phone" mask={phoneMask} />
               </FormField>

--- a/aries-site/src/examples/templates/forms/SignInExample.js
+++ b/aries-site/src/examples/templates/forms/SignInExample.js
@@ -8,7 +8,6 @@ import {
   Form,
   FormField,
   Header,
-  Heading,
   Layer,
   Text,
   TextInput,
@@ -69,9 +68,9 @@ const ResetPassword = ({ closeLayer, email }) => {
         margin={{ horizontal: 'xlarge', bottom: 'xlarge', top: 'large' }}
         width="medium"
       >
-        <Heading level={2} margin="none">
+        <Text size="xxlarge" weight="bold">
           Reset Password
-        </Heading>
+        </Text>
         <Form
           validate="blur"
           value={formValues}
@@ -130,9 +129,9 @@ export const SignInExample = () => {
           gap="xxsmall"
           pad={{ horizontal: 'xxsmall' }}
         >
-          <Heading level={3} margin="none">
+          <Text size="xxlarge" weight="bold">
             Sign In
-          </Heading>
+          </Text>
           <Text>to Hewlett Packard Enterprise</Text>
         </Header>
         <Box
@@ -166,7 +165,7 @@ export const SignInExample = () => {
               <TextInput
                 id="password-sign-in"
                 name="password"
-                placeholder="•••••••••••••••"
+                placeholder="Enter your password"
                 type="password"
               />
             </FormField>

--- a/aries-site/src/examples/templates/forms/SignUpExample.js
+++ b/aries-site/src/examples/templates/forms/SignUpExample.js
@@ -7,7 +7,6 @@ import {
   Form,
   FormField,
   Header,
-  Heading,
   MaskedInput,
   Text,
   TextInput,
@@ -103,9 +102,9 @@ export const SignUpExample = () => {
           gap="xxsmall"
           pad={{ horizontal: 'xxsmall' }}
         >
-          <Heading level={3} margin="none">
+          <Text size="xxlarge" weight="bold">
             Sign Up
-          </Heading>
+          </Text>
           <Text>for a Hewlett Packard Enterprise account</Text>
         </Header>
         <Box
@@ -154,7 +153,7 @@ export const SignUpExample = () => {
               <TextInput
                 id="password-sign-up"
                 name="password"
-                placeholder="•••••••••••••••"
+                placeholder="Enter your password"
                 type="password"
               />
             </FormField>

--- a/aries-site/src/examples/templates/forms/SimpleSignUpExample.js
+++ b/aries-site/src/examples/templates/forms/SimpleSignUpExample.js
@@ -7,7 +7,6 @@ import {
   Form,
   FormField,
   Header,
-  Heading,
   MaskedInput,
   Text,
   TextInput,
@@ -103,9 +102,9 @@ export const SimpleSignUpExample = () => {
           gap="xxsmall"
           pad={{ horizontal: 'xxsmall' }}
         >
-          <Heading level={3} margin="none">
+          <Text size="xxlarge" weight="bold">
             Sign Up
-          </Heading>
+          </Text>
           <Text>for a Hewlett Packard Enterprise account</Text>
         </Header>
         <Box
@@ -152,7 +151,7 @@ export const SimpleSignUpExample = () => {
               <TextInput
                 id="password-sign-up-simple"
                 name="password"
-                placeholder="•••••••••••••••"
+                placeholder="Enter your password"
                 type="password"
               />
             </FormField>

--- a/aries-site/src/examples/templates/forms/SortExample.js
+++ b/aries-site/src/examples/templates/forms/SortExample.js
@@ -4,9 +4,9 @@ import {
   Form,
   FormField,
   Header,
-  Heading,
   RadioButtonGroup,
   Select,
+  Text,
 } from 'grommet';
 
 const sortFeatures = ['Featured', 'Price', 'Users'];
@@ -14,11 +14,7 @@ const sortFeatures = ['Featured', 'Price', 'Users'];
 const FormContainer = ({ ...rest }) => {
   return (
     <Box background="background-front" border round="small" overflow="hidden">
-      <Box
-        flex
-        pad={{ horizontal: 'medium', vertical: 'medium' }}
-        {...rest}
-       />
+      <Box flex pad={{ horizontal: 'medium', vertical: 'medium' }} {...rest} />
     </Box>
   );
 };
@@ -47,9 +43,9 @@ export const SortExample = () => {
           gap="xxsmall"
           pad={{ horizontal: 'xxsmall' }}
         >
-          <Heading level={3} margin="none">
+          <Text size="xxlarge" weight="bold">
             Sort
-          </Heading>
+          </Text>
         </Header>
         <Box
           // Padding used to prevent focus from being cutoff


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

Uses `Text` in forms instead of `Heading` since we can't anticipate which would be the proper Heading level for a user's context. Also, updates password placeholder text to say "Enter your password" instead of using "•••••••"

#### Where should the reviewer start?
Any file.

#### What testing has been done on this PR?
All e2e checks were run and passed.

#### How should this be manually tested?
View the deployment link.

#### Any background context you want to provide?
https://grommet.slack.com/archives/C04LMJWQT/p1595469604030500

#### What are the relevant issues?
Closes #994 

#### Screenshots (if appropriate)

#### Should this PR be mentioned in Design System updates?
Yes.

#### Is this change backwards compatible or is it a breaking change?
Yes, backwards compatible.