### PR TITLE
fix background color for validation password

### DIFF
--- a/aries-site/src/examples/templates/forms/ShippingExample.js
+++ b/aries-site/src/examples/templates/forms/ShippingExample.js
@@ -127,14 +127,14 @@ const emailValidation = [
     message: (
       <Error background="background-front">Enter a valid email address.</Error>
     ),
-    status: 'info',
+    status: 'error',
   },
   {
     regexp: new RegExp('[^@ \\t\\r\\n]+@[^@ \\t\\r\\n]+\\.[^@ \\t\\r\\n]+'),
     message: (
       <Error background="background-front">Enter a valid email address.</Error>
     ),
-    status: 'info',
+    status: 'error',
   },
   {
     regexp: new RegExp('[^@ \\t\\r\\n]+@[^@ \\t\\r\\n]+\\.[^@ \\t\\r\\n]+'),

--- a/aries-site/src/examples/templates/forms/ShippingExample.js
+++ b/aries-site/src/examples/templates/forms/ShippingExample.js
@@ -12,6 +12,22 @@ import {
   Text,
   TextInput,
 } from 'grommet';
+import { CircleAlert } from 'grommet-icons';
+
+const Error = ({ children, ...rest }) => {
+  return (
+    <Box direction="row" gap="xsmall" {...rest}>
+      <Box flex={false} margin={{ top: 'hair' }} pad={{ top: 'xxsmall' }}>
+        <CircleAlert size="small" />
+      </Box>
+      <Text size="xsmall">{children}</Text>
+    </Box>
+  );
+};
+
+Error.propTypes = {
+  children: PropTypes.object,
+};
 
 const emailMask = [
   {
@@ -108,17 +124,23 @@ const phoneMask = [
 const emailValidation = [
   {
     regexp: new RegExp('[^@ \\t\\r\\n]+@'),
-    message: 'Missing an @?',
+    message: (
+      <Error background="background-front">Enter a valid email address.</Error>
+    ),
     status: 'info',
   },
   {
     regexp: new RegExp('[^@ \\t\\r\\n]+@[^@ \\t\\r\\n]+\\.[^@ \\t\\r\\n]+'),
-    message: 'Missing an .?',
+    message: (
+      <Error background="background-front">Enter a valid email address.</Error>
+    ),
     status: 'info',
   },
   {
     regexp: new RegExp('[^@ \\t\\r\\n]+@[^@ \\t\\r\\n]+\\.[^@ \\t\\r\\n]+'),
-    message: "Email address doesn't look quite right",
+    message: (
+      <Error background="background-front">Enter a valid email address.</Error>
+    ),
     status: 'error',
   },
 ];
@@ -178,7 +200,11 @@ export const ShippingExample = () => {
             value={formValues}
             onChange={setFormValues}
             messages={{
-              required: '! This is a required field.',
+              required: (
+                <Error background="background-front">
+                  This is a required field.
+                </Error>
+              ),
             }}
             onSubmit={({ value, touched }) => onSubmit({ value, touched })}
           >

--- a/aries-site/src/examples/templates/forms/SignUpExample.js
+++ b/aries-site/src/examples/templates/forms/SignUpExample.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import {
   Anchor,
   Box,
@@ -12,22 +13,55 @@ import {
   Text,
   TextInput,
 } from 'grommet';
-import { FormCheckmark, FormClose } from 'grommet-icons';
+import { FormCheckmark, CircleAlert } from 'grommet-icons';
+
+const Error = ({ children, ...rest }) => {
+  return (
+    <Box direction="row" gap="xsmall" {...rest}>
+      <Box flex={false} margin={{ top: 'hair' }} pad={{ top: 'xxsmall' }}>
+        <CircleAlert size="small" />
+      </Box>
+      <Text size="xsmall">{children}</Text>
+    </Box>
+  );
+};
+
+Error.propTypes = {
+  children: PropTypes.object,
+};
+
+const passwordRequirements = [
+  {
+    regexp: new RegExp('(?=.*?[A-Z])(?=.*?[a-z])(?=.*?[#?!@$ %^&*-]).{8,}'),
+    message: (
+      <Error background="background-front">
+        Password requirements not meet.
+      </Error>
+    ),
+    status: 'error',
+  },
+];
 
 const emailValidation = [
   {
     regexp: new RegExp('[^@ \\t\\r\\n]+@'),
-    message: 'Missing an @?',
-    status: 'info',
+    message: (
+      <Error background="background-front">Enter a valid email address.</Error>
+    ),
+    status: 'error',
   },
   {
     regexp: new RegExp('[^@ \\t\\r\\n]+@[^@ \\t\\r\\n]+\\.[^@ \\t\\r\\n]+'),
-    message: 'Missing an .?',
-    status: 'info',
+    message: (
+      <Error background="background-front">Enter a valid email address.</Error>
+    ),
+    status: 'error',
   },
   {
     regexp: new RegExp('[^@ \\t\\r\\n]+@[^@ \\t\\r\\n]+\\.[^@ \\t\\r\\n]+'),
-    message: "Email address doesn't look quite right",
+    message: (
+      <Error background="background-front">Enter a valid email address.</Error>
+    ),
     status: 'error',
   },
 ];
@@ -153,6 +187,7 @@ export const SignUpExample = () => {
             </FormField>
             <FormField
               label="Password"
+              validate={passwordRequirements}
               htmlFor="password-sign-up"
               name="password"
               required
@@ -180,9 +215,7 @@ export const SignUpExample = () => {
                             <FormCheckmark size="small" />
                           </Box>
                         ) : (
-                          <Box alignSelf="center">
-                            <FormClose size="small" />
-                          </Box>
+                          <></>
                         )}
                         <Text size="xsmall">{rule.message}</Text>
                       </Box>

--- a/aries-site/src/examples/templates/forms/SignUpExample.js
+++ b/aries-site/src/examples/templates/forms/SignUpExample.js
@@ -13,7 +13,6 @@ import {
   TextInput,
 } from 'grommet';
 import { FormCheckmark, FormClose } from 'grommet-icons';
-import { useDarkMode } from '../../../utils';
 
 const emailValidation = [
   {
@@ -82,16 +81,10 @@ const FormContainer = ({ ...rest }) => {
 };
 
 export const SignUpExample = () => {
-  const themeMode = useDarkMode().value ? 'dark' : 'light';
   const [formValues, setFormValues] = React.useState({
     email: 'jane.smith@hpe.com',
   });
-  const [backgroundError, setBackgroundError] = React.useState('');
   const [passwordRules, setPasswordRules] = React.useState(passwordRulesStrong);
-  //  Since password rules are being checked outside the validation
-  //  and being passed in the info message the background color is not
-  //  being changed. We need to check if all password rules are applied
-  //  then we can change background color to indicate there is no error.
 
   const onChange = values => {
     setFormValues(values);
@@ -99,11 +92,6 @@ export const SignUpExample = () => {
       const adjustedRule = { ...rule };
       const valid = adjustedRule.regexp.test(values.password);
       adjustedRule.valid = valid;
-      if (valid !== true) {
-        setBackgroundError(themeMode === 'dark' ? '#C54E4B5C' : '#FC61613D');
-      } else {
-        setBackgroundError('');
-      }
       return adjustedRule;
     });
     setPasswordRules(adjustedPasswordRules);
@@ -204,7 +192,6 @@ export const SignUpExample = () => {
               }
             >
               <TextInput
-                style={{ backgroundColor: backgroundError }}
                 id="password-sign-up"
                 name="password"
                 placeholder="Enter your password"

--- a/aries-site/src/examples/templates/forms/SignUpExample.js
+++ b/aries-site/src/examples/templates/forms/SignUpExample.js
@@ -210,12 +210,10 @@ export const SignUpExample = () => {
                     }
                     return (
                       <Box direction="row" gap="xsmall">
-                        {formValues.password && rule.valid ? (
+                        {formValues.password && rule.valid && (
                           <Box alignSelf="center">
                             <FormCheckmark size="small" />
                           </Box>
-                        ) : (
-                          <></>
                         )}
                         <Text size="xsmall">{rule.message}</Text>
                       </Box>

--- a/aries-site/src/examples/templates/forms/SignUpExample.js
+++ b/aries-site/src/examples/templates/forms/SignUpExample.js
@@ -13,6 +13,7 @@ import {
   TextInput,
 } from 'grommet';
 import { FormCheckmark, FormClose } from 'grommet-icons';
+import { useDarkMode } from '../../../utils';
 
 const emailValidation = [
   {
@@ -81,10 +82,11 @@ const FormContainer = ({ ...rest }) => {
 };
 
 export const SignUpExample = () => {
+  const themeMode = useDarkMode().value ? 'dark' : 'light';
   const [formValues, setFormValues] = React.useState({
     email: 'jane.smith@hpe.com',
   });
-  const [backgroundError, setBackgroundError] = React.useState('white');
+  const [backgroundError, setBackgroundError] = React.useState('');
   const [passwordRules, setPasswordRules] = React.useState(passwordRulesStrong);
 
   const onChange = values => {
@@ -94,9 +96,9 @@ export const SignUpExample = () => {
       const valid = adjustedRule.regexp.test(values.password);
       adjustedRule.valid = valid;
       if (valid !== true) {
-        setBackgroundError('#FC61613D');
+        setBackgroundError(themeMode === 'dark' ? '#C54E4B5C' : '#FC61613D');
       } else {
-        setBackgroundError('white');
+        setBackgroundError('');
       }
       return adjustedRule;
     });

--- a/aries-site/src/examples/templates/forms/SignUpExample.js
+++ b/aries-site/src/examples/templates/forms/SignUpExample.js
@@ -35,7 +35,7 @@ const passwordRequirements = [
     regexp: new RegExp('(?=.*?[A-Z])(?=.*?[a-z])(?=.*?[#?!@$ %^&*-]).{8,}'),
     message: (
       <Error background="background-front">
-        Password requirements not meet.
+        Password requirements not met.
       </Error>
     ),
     status: 'error',

--- a/aries-site/src/examples/templates/forms/SignUpExample.js
+++ b/aries-site/src/examples/templates/forms/SignUpExample.js
@@ -88,6 +88,10 @@ export const SignUpExample = () => {
   });
   const [backgroundError, setBackgroundError] = React.useState('');
   const [passwordRules, setPasswordRules] = React.useState(passwordRulesStrong);
+  //  Since password rules are being checked outside the validation
+  //  and being passed in the info message the background color is not
+  //  being changed. We need to check if all password rules are applied
+  //  then we can change background color to indicate there is no error.
 
   const onChange = values => {
     setFormValues(values);

--- a/aries-site/src/examples/templates/forms/SignUpExample.js
+++ b/aries-site/src/examples/templates/forms/SignUpExample.js
@@ -84,6 +84,7 @@ export const SignUpExample = () => {
   const [formValues, setFormValues] = React.useState({
     email: 'jane.smith@hpe.com',
   });
+  const [backgroundError, setBackgroundError] = React.useState('white');
   const [passwordRules, setPasswordRules] = React.useState(passwordRulesStrong);
 
   const onChange = values => {
@@ -92,6 +93,11 @@ export const SignUpExample = () => {
       const adjustedRule = { ...rule };
       const valid = adjustedRule.regexp.test(values.password);
       adjustedRule.valid = valid;
+      if (valid !== true) {
+        setBackgroundError('#FC61613D');
+      } else {
+        setBackgroundError('white');
+      }
       return adjustedRule;
     });
     setPasswordRules(adjustedPasswordRules);
@@ -191,6 +197,7 @@ export const SignUpExample = () => {
               }
             >
               <TextInput
+                style={{ backgroundColor: backgroundError }}
                 id="password-sign-up"
                 name="password"
                 placeholder="Enter your password"

--- a/aries-site/src/examples/templates/forms/SimpleSignUpExample.js
+++ b/aries-site/src/examples/templates/forms/SimpleSignUpExample.js
@@ -87,6 +87,11 @@ export const SimpleSignUpExample = () => {
   const [backgroundError, setBackgroundError] = React.useState('');
   const [passwordRules, setPasswordRules] = React.useState(passwordRulesStrong);
 
+  // Since password rules are being checked outside the validation
+  // and being passed in the info message the background color is not
+  // being changed. We need to check if all password rules are applied
+  // then we can change background color to indicate there is no error.
+
   const onChange = values => {
     setFormValues(values);
     const adjustedPasswordRules = passwordRules.map(rule => {

--- a/aries-site/src/examples/templates/forms/SimpleSignUpExample.js
+++ b/aries-site/src/examples/templates/forms/SimpleSignUpExample.js
@@ -13,7 +13,6 @@ import {
   TextInput,
 } from 'grommet';
 import { FormCheckmark, FormClose } from 'grommet-icons';
-import { useDarkMode } from '../../../utils';
 
 const passwordRulesStrong = [
   {
@@ -82,17 +81,10 @@ const FormContainer = ({ ...rest }) => {
 };
 
 export const SimpleSignUpExample = () => {
-  const themeMode = useDarkMode().value ? 'dark' : 'light';
   const [formValues, setFormValues] = React.useState({
     email: 'jane.smith@hpe.com',
   });
-  const [backgroundError, setBackgroundError] = React.useState('');
   const [passwordRules, setPasswordRules] = React.useState(passwordRulesStrong);
-
-  // Since password rules are being checked outside the validation
-  // and being passed in the info message the background color is not
-  // being changed. We need to check if all password rules are applied
-  // then we can change background color to indicate there is no error.
 
   const onChange = values => {
     setFormValues(values);
@@ -100,11 +92,6 @@ export const SimpleSignUpExample = () => {
       const adjustedRule = { ...rule };
       const valid = adjustedRule.regexp.test(values.password);
       adjustedRule.valid = valid;
-      if (valid !== true) {
-        setBackgroundError(themeMode === 'dark' ? '#C54E4B5C' : '#FC61613D');
-      } else {
-        setBackgroundError('');
-      }
       return adjustedRule;
     });
     setPasswordRules(adjustedPasswordRules);
@@ -204,7 +191,6 @@ export const SimpleSignUpExample = () => {
               }
             >
               <TextInput
-                style={{ backgroundColor: backgroundError }}
                 id="password-sign-up-simple"
                 name="password"
                 placeholder="Enter your password"

--- a/aries-site/src/examples/templates/forms/SimpleSignUpExample.js
+++ b/aries-site/src/examples/templates/forms/SimpleSignUpExample.js
@@ -209,12 +209,10 @@ export const SimpleSignUpExample = () => {
                     }
                     return (
                       <Box direction="row" gap="xsmall">
-                        {formValues.password && rule.valid ? (
+                        {formValues.password && rule.valid && (
                           <Box alignSelf="center">
                             <FormCheckmark size="small" />
                           </Box>
-                        ) : (
-                          <></>
                         )}
                         <Text size="xsmall">{rule.message}</Text>
                       </Box>

--- a/aries-site/src/examples/templates/forms/SimpleSignUpExample.js
+++ b/aries-site/src/examples/templates/forms/SimpleSignUpExample.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import {
   Anchor,
   Box,
@@ -12,7 +13,34 @@ import {
   Text,
   TextInput,
 } from 'grommet';
-import { FormCheckmark, FormClose } from 'grommet-icons';
+import { FormCheckmark, CircleAlert } from 'grommet-icons';
+
+const Error = ({ children, ...rest }) => {
+  return (
+    <Box direction="row" gap="xsmall" {...rest}>
+      <Box flex={false} margin={{ top: 'hair' }} pad={{ top: 'xxsmall' }}>
+        <CircleAlert size="small" />
+      </Box>
+      <Text size="xsmall">{children}</Text>
+    </Box>
+  );
+};
+
+Error.propTypes = {
+  children: PropTypes.object,
+};
+
+const passwordRequirements = [
+  {
+    regexp: new RegExp('(?=.*?[A-Z])(?=.*?[a-z])(?=.*?[#?!@$ %^&*-]).{8,}'),
+    message: (
+      <Error background="background-front">
+        Password requirements not meet.
+      </Error>
+    ),
+    status: 'error',
+  },
+];
 
 const passwordRulesStrong = [
   {
@@ -40,17 +68,23 @@ const passwordRulesStrong = [
 const emailValidation = [
   {
     regexp: new RegExp('[^@ \\t\\r\\n]+@'),
-    message: 'Missing an @?',
-    status: 'info',
+    message: (
+      <Error background="background-front">Enter a valid email address.</Error>
+    ),
+    status: 'error',
   },
   {
     regexp: new RegExp('[^@ \\t\\r\\n]+@[^@ \\t\\r\\n]+\\.[^@ \\t\\r\\n]+'),
-    message: 'Missing an .?',
-    status: 'info',
+    message: (
+      <Error background="background-front">Enter a valid email address.</Error>
+    ),
+    status: 'error',
   },
   {
     regexp: new RegExp('[^@ \\t\\r\\n]+@[^@ \\t\\r\\n]+\\.[^@ \\t\\r\\n]+'),
-    message: "Email address doesn't look quite right",
+    message: (
+      <Error background="background-front">Enter a valid email address.</Error>
+    ),
     status: 'error',
   },
 ];
@@ -153,6 +187,7 @@ export const SimpleSignUpExample = () => {
             </FormField>
             <FormField
               label="Password"
+              validate={passwordRequirements}
               htmlFor="password-sign-up-simple"
               name="password"
               info={
@@ -179,9 +214,7 @@ export const SimpleSignUpExample = () => {
                             <FormCheckmark size="small" />
                           </Box>
                         ) : (
-                          <Box alignSelf="center">
-                            <FormClose size="small" />
-                          </Box>
+                          <></>
                         )}
                         <Text size="xsmall">{rule.message}</Text>
                       </Box>

--- a/aries-site/src/examples/templates/forms/SimpleSignUpExample.js
+++ b/aries-site/src/examples/templates/forms/SimpleSignUpExample.js
@@ -13,6 +13,7 @@ import {
   TextInput,
 } from 'grommet';
 import { FormCheckmark, FormClose } from 'grommet-icons';
+import { useDarkMode } from '../../../utils';
 
 const passwordRulesStrong = [
   {
@@ -81,6 +82,7 @@ const FormContainer = ({ ...rest }) => {
 };
 
 export const SimpleSignUpExample = () => {
+  const themeMode = useDarkMode().value ? 'dark' : 'light';
   const [formValues, setFormValues] = React.useState({
     email: 'jane.smith@hpe.com',
   });
@@ -99,7 +101,7 @@ export const SimpleSignUpExample = () => {
       const valid = adjustedRule.regexp.test(values.password);
       adjustedRule.valid = valid;
       if (valid !== true) {
-        setBackgroundError('#FC61613D');
+        setBackgroundError(themeMode === 'dark' ? '#C54E4B5C' : '#FC61613D');
       } else {
         setBackgroundError('');
       }

--- a/aries-site/src/examples/templates/forms/SimpleSignUpExample.js
+++ b/aries-site/src/examples/templates/forms/SimpleSignUpExample.js
@@ -84,7 +84,7 @@ export const SimpleSignUpExample = () => {
   const [formValues, setFormValues] = React.useState({
     email: 'jane.smith@hpe.com',
   });
-  const [backgroundError, setBackgroundError] = React.useState('white');
+  const [backgroundError, setBackgroundError] = React.useState('');
   const [passwordRules, setPasswordRules] = React.useState(passwordRulesStrong);
 
   const onChange = values => {
@@ -96,7 +96,7 @@ export const SimpleSignUpExample = () => {
       if (valid !== true) {
         setBackgroundError('#FC61613D');
       } else {
-        setBackgroundError('white');
+        setBackgroundError('');
       }
       return adjustedRule;
     });

--- a/aries-site/src/examples/templates/forms/SimpleSignUpExample.js
+++ b/aries-site/src/examples/templates/forms/SimpleSignUpExample.js
@@ -35,7 +35,7 @@ const passwordRequirements = [
     regexp: new RegExp('(?=.*?[A-Z])(?=.*?[a-z])(?=.*?[#?!@$ %^&*-]).{8,}'),
     message: (
       <Error background="background-front">
-        Password requirements not meet.
+        Password requirements not met.
       </Error>
     ),
     status: 'error',

--- a/aries-site/src/examples/templates/forms/SimpleSignUpExample.js
+++ b/aries-site/src/examples/templates/forms/SimpleSignUpExample.js
@@ -84,6 +84,7 @@ export const SimpleSignUpExample = () => {
   const [formValues, setFormValues] = React.useState({
     email: 'jane.smith@hpe.com',
   });
+  const [backgroundError, setBackgroundError] = React.useState('white');
   const [passwordRules, setPasswordRules] = React.useState(passwordRulesStrong);
 
   const onChange = values => {
@@ -92,6 +93,11 @@ export const SimpleSignUpExample = () => {
       const adjustedRule = { ...rule };
       const valid = adjustedRule.regexp.test(values.password);
       adjustedRule.valid = valid;
+      if (valid !== true) {
+        setBackgroundError('#FC61613D');
+      } else {
+        setBackgroundError('white');
+      }
       return adjustedRule;
     });
     setPasswordRules(adjustedPasswordRules);
@@ -191,6 +197,7 @@ export const SimpleSignUpExample = () => {
               }
             >
               <TextInput
+                style={{ backgroundColor: backgroundError }}
                 id="password-sign-up-simple"
                 name="password"
                 placeholder="Enter your password"


### PR DESCRIPTION
[Preview](https://deploy-preview-1002--keen-mayer-a86c8b.netlify.app/templates/forms)
In the first iteration of password validation the background was just white regardless of whether the checks were true for password. I wanted to match up better with designs so the background color is the same error red color if all the checks are not meet.