### PR TITLE
Don't wrap external links in next/link

### DIFF
--- a/aries-site/src/examples/templates/forms/SignInExample.js
+++ b/aries-site/src/examples/templates/forms/SignInExample.js
@@ -148,8 +148,8 @@ export const SignInExample = () => {
   // eslint-disable-next-line no-unused-vars
   const onSubmit = ({ value, touched }) => {
     // Your submission logic here
-    // For demonstration purposes, we are mocking a scenario where the password is incorrect.
-    // This will cause the error state to appear.
+    // For demonstration purposes, we are mocking a scenario where the password
+    // is incorrect. This will cause the error state to appear.
     if (password !== 'password') {
       setCredentialError(true);
     }

--- a/aries-site/src/layouts/main/Footer.js
+++ b/aries-site/src/layouts/main/Footer.js
@@ -44,14 +44,12 @@ export const Footer = () => {
         <Box direction="row" gap="xsmall">
           {externalFooterLinks.map(item => (
             <Box key={item.name} align="start">
-              <Link href={item.href} passHref>
-                <Button
-                  label={item.name}
-                  active={router.pathname === item.href}
-                  target="_blank"
-                  rel="noreferrer noopener"
-                />
-              </Link>
+              <Button
+                label={item.name}
+                active={router.pathname === item.href}
+                target="_blank"
+                rel="noreferrer noopener"
+              />
             </Box>
           ))}
           {/* Need to pass href because of:


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
Removes the <Link> wrapper from footer links. This should only be used for internal routing, but the footer links direct to external links.

#### Where should the reviewer start?
aries-site/src/layouts/main/Footer.js

#### What testing has been done on this PR?

Prior, when you scrolled to the bottom of the page, the below error would pop up. Now, this doesn't happen.

#### How should this be manually tested?

#### Any background context you want to provide?

#### What are the relevant issues?

#### Screenshots (if appropriate)
<img width="980" alt="Screen Shot 2020-08-05 at 4 21 12 PM" src="https://user-images.githubusercontent.com/12522275/89473769-91a6f580-d738-11ea-8c4c-b9dde8df37c8.png">

#### Should this PR be mentioned in Design System updates?
No.
#### Is this change backwards compatible or is it a breaking change?
Yes, backwards compatible.