### PR TITLE
Remove sticky footer from Wizard

### DIFF
--- a/aries-site/src/examples/templates/wizard/StickyHeaderFooterExample.js
+++ b/aries-site/src/examples/templates/wizard/StickyHeaderFooterExample.js
@@ -8,7 +8,6 @@ import {
   Heading,
   Form,
   FormField,
-  Footer,
   Layer,
   List,
   RadioButtonGroup,
@@ -25,62 +24,92 @@ import {
   FormPreviousLink,
 } from 'grommet-icons';
 
-const StepOne = () => (
-  <Box>
-    <FormField label="Text Input" htmlFor="text-input" name="text-input">
-      <TextInput
-        placeholder="Placeholder text"
-        id="text-input"
-        name="text-input"
-      />
-    </FormField>
-    <FormField
-      help="Click on the ‘eye’ icon for the description text field to hide."
-      htmlFor="radio-button-group"
-      label="RadioButtonGroup"
-      name="radio-button-group"
-    >
-      <RadioButtonGroup
-        id="radio-button-group"
+const StepOne = ({ active, setActive }) => (
+  <>
+    <Box margin={{ bottom: 'large' }}>
+      <FormField label="Text Input" htmlFor="text-input" name="text-input">
+        <TextInput
+          placeholder="Placeholder text"
+          id="text-input"
+          name="text-input"
+        />
+      </FormField>
+      <FormField
+        help="Click on the ‘eye’ icon for the description text field to hide."
+        htmlFor="radio-button-group"
+        label="RadioButtonGroup"
         name="radio-button-group"
-        options={['Radio button 1', 'Radio button 2']}
-      />
-    </FormField>
-  </Box>
+      >
+        <RadioButtonGroup
+          id="radio-button-group"
+          name="radio-button-group"
+          options={['Radio button 1', 'Radio button 2']}
+        />
+      </FormField>
+    </Box>
+    <Button
+      fill="horizontal"
+      label="Next"
+      icon={<FormNextLink />}
+      primary
+      reverse
+      onClick={() => setActive(active + 1)}
+    />
+  </>
 );
 
-const StepTwo = () => (
-  <Box>
-    <FormField label="Select" htmlFor="select" name="select">
-      <Select
-        placeholder="Select item"
-        id="select"
-        name="select"
-        options={['Option 1', 'Option 2']}
-      />
-    </FormField>
-    <FormField htmlFor="checkboxgroup" label="Label" name="checkboxgroup">
-      <CheckBoxGroup
-        id="checkboxgroup"
-        name="checkboxgroup"
-        options={['CheckBox 1', 'CheckBox 2']}
-      />
-    </FormField>
-    <FormField
-      help="Description of how to use this field"
-      htmlFor="text-area"
-      label="Label"
-      name="text-area"
-    >
-      <TextArea
-        id="text-area"
+StepOne.propTypes = {
+  active: PropTypes.number.isRequired,
+  setActive: PropTypes.func.isRequired,
+};
+
+const StepTwo = ({ active, setActive }) => (
+  <>
+    <Box margin={{ bottom: 'large' }}>
+      <FormField label="Select" htmlFor="select" name="select">
+        <Select
+          placeholder="Select item"
+          id="select"
+          name="select"
+          options={['Option 1', 'Option 2']}
+        />
+      </FormField>
+      <FormField htmlFor="checkboxgroup" label="Label" name="checkboxgroup">
+        <CheckBoxGroup
+          id="checkboxgroup"
+          name="checkboxgroup"
+          options={['CheckBox 1', 'CheckBox 2']}
+        />
+      </FormField>
+      <FormField
+        help="Description of how to use this field"
+        htmlFor="text-area"
+        label="Label"
         name="text-area"
-        options={['CheckBox 1', 'CheckBox 2']}
-        placeholder="Placeholder text"
-      />
-    </FormField>
-  </Box>
+      >
+        <TextArea
+          id="text-area"
+          name="text-area"
+          options={['CheckBox 1', 'CheckBox 2']}
+          placeholder="Placeholder text"
+        />
+      </FormField>
+    </Box>
+    <Button
+      fill="horizontal"
+      label="Next"
+      icon={<FormNextLink />}
+      primary
+      reverse
+      onClick={() => setActive(active + 1)}
+    />
+  </>
 );
+
+StepTwo.propTypes = {
+  active: PropTypes.number.isRequired,
+  setActive: PropTypes.func.isRequired,
+};
 
 const data = [
   'Summary value of step 1',
@@ -91,19 +120,22 @@ const data = [
 
 const StepThree = () => {
   return (
-    <Box gap="small">
-      <List data={data} pad={{ horizontal: 'none', vertical: 'small' }}>
-        {(datum, index) => (
-          <Box key={index} direction="row" gap="medium" align="center">
-            <Checkmark color="text-strong" size="small" />
-            <Text color="text-strong">{datum}</Text>
-          </Box>
-        )}
-      </List>
-      <Text color="text-strong">
-        Include guidance to what will occur when “Finish Setup” is clicked.
-      </Text>
-    </Box>
+    <>
+      <Box gap="small" margin={{ bottom: 'large' }}>
+        <List data={data} pad={{ horizontal: 'none', vertical: 'small' }}>
+          {(datum, index) => (
+            <Box key={index} direction="row" gap="medium" align="center">
+              <Checkmark color="text-strong" size="small" />
+              <Text color="text-strong">{datum}</Text>
+            </Box>
+          )}
+        </List>
+        <Text color="text-strong">
+          Include guidance to what will occur when “Finish Setup” is clicked.
+        </Text>
+      </Box>
+      <Button fill="horizontal" label="Finish Setup" primary type="submit" />
+    </>
   );
 };
 
@@ -142,16 +174,15 @@ export const StickyHeaderFooterExample = () => {
   const size = useContext(ResponsiveContext);
   return (
     <>
-      <Box fill>
+      <Box width={{ max: 'xxlarge' }} margin="auto" fill>
         <WizardHeader active={active} setActive={setActive} setOpen={setOpen} />
         <Box
           align="center"
           pad={size !== 'small' ? 'large' : 'medium'}
-          //   flex={false}
           flex
           overflow="auto"
         >
-          <Box width="medium" gap="medium">
+          <Box width="medium" gap="medium" flex={false}>
             <Box gap="medium" flex={false}>
               <Box>
                 <Heading color="text-strong" margin="none">
@@ -177,7 +208,6 @@ export const StickyHeaderFooterExample = () => {
             </Form>
           </Box>
         </Box>
-        <WizardFooter active={active} setActive={setActive} />
       </Box>
       {open && <CancellationLayer onSetOpen={setOpen} />}
     </>
@@ -224,43 +254,6 @@ WizardHeader.propTypes = {
   active: PropTypes.number.isRequired,
   setActive: PropTypes.func.isRequired,
   setOpen: PropTypes.func.isRequired,
-};
-
-const WizardFooter = ({ active, setActive }) => {
-  return (
-    <Footer
-      border={{ side: 'bottom', color: 'border-weak' }}
-      pad="small"
-      fill="horizontal"
-      justify="center"
-      flex={false}
-    >
-      <Box width="medium">
-        {active < steps.length ? (
-          <Button
-            fill="horizontal"
-            label="Next"
-            icon={<FormNextLink />}
-            primary
-            reverse
-            onClick={() => setActive(active + 1)}
-          />
-        ) : (
-          <Button
-            fill="horizontal"
-            label="Finish Setup"
-            primary
-            type="submit"
-          />
-        )}
-      </Box>
-    </Footer>
-  );
-};
-
-WizardFooter.propTypes = {
-  active: PropTypes.number.isRequired,
-  setActive: PropTypes.func.isRequired,
 };
 
 const CancellationLayer = ({ onSetOpen }) => {

--- a/aries-site/src/pages/templates/wizard.mdx
+++ b/aries-site/src/pages/templates/wizard.mdx
@@ -60,7 +60,7 @@ If guidance can be provided in a short description, use a single column wizard. 
 
 Common wizard variants.
 
-### Sticky Header and Footer Wizard
+### Sticky Header Wizard
 
 Using a sticky header and footer allows the user to easily access buttons that allow to advance or move back within the wizard.
 

--- a/aries-site/src/pages/templates/wizard.mdx
+++ b/aries-site/src/pages/templates/wizard.mdx
@@ -62,7 +62,7 @@ Common wizard variants.
 
 ### Sticky Header Wizard
 
-Using a sticky header and footer allows the user to easily access buttons that allow to advance or move back within the wizard.
+Using a sticky header allows the user to easily access the buttons that allow them to move back to a previous step or cancel.
 
 <Example
   code="https://raw.githubusercontent.com/hpe-design/design-system/master/aries-site/src/examples/templates/wizard/StickyHeaderFooterExample.js"


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
Updates the sticky header footer wizard example only to have a sticky header. After discussion with Greg, our recommended behavior is that the "Next" button should always follow under form inputs.

#### Where should the reviewer start?
aries-site/src/examples/templates/wizard/StickyHeaderFooterExample.js

#### What testing has been done on this PR?
e2e and viewed deploy on Chrome, Safari, and FF

#### How should this be manually tested?
Look at deploy.

#### Any background context you want to provide?

#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Should this PR be mentioned in Design System updates?
No.

#### Is this change backwards compatible or is it a breaking change?
Yes.