### PR TITLE
switch button example

### DIFF
--- a/aries-site/src/pages/components/button.mdx
+++ b/aries-site/src/pages/components/button.mdx
@@ -103,7 +103,7 @@ When looking to accent an interaction or for special use cases that require more
   docs="https://v2.grommet.io/button?theme=hpe#props"
   height={{ min: 'small' }}
 >
-  <DefaultButtonExample />
+  <ColorButtonExample />
 </Example>
 
 ### Button with Icon


### PR DESCRIPTION
Default button example was being called twice. 
Color button example should be called 