### PR TITLE
Toggle inline example off when layer is open

### DIFF
--- a/aries-site/src/examples/templates/wizard/StickyHeaderFooterExample.js
+++ b/aries-site/src/examples/templates/wizard/StickyHeaderFooterExample.js
@@ -36,12 +36,12 @@ const StepOne = ({ active, setActive }) => (
       </FormField>
       <FormField
         help="Click on the ‘eye’ icon for the description text field to hide."
-        htmlFor="radio-button-group"
+        htmlFor="radio-button-group-sticky"
         label="RadioButtonGroup"
         name="radio-button-group"
       >
         <RadioButtonGroup
-          id="radio-button-group"
+          id="radio-button-group-sticky"
           name="radio-button-group"
           options={['Radio button 1', 'Radio button 2']}
         />

--- a/aries-site/src/layouts/content/Example/Example.js
+++ b/aries-site/src/layouts/content/Example/Example.js
@@ -89,21 +89,25 @@ export const Example = ({
             }
             {...rest}
           >
-            <ExampleWrapper
-              background={
-                ExampleWrapper === ResponsiveContainer && background
-                  ? background
-                  : undefined
-              }
-              screen={screen}
-              width={width}
-            >
-              <ResponsiveContext.Provider
-                value={screen === screens.mobile && 'small'}
+            {/* when Layer is open, we remove the inline Example to avoid 
+            repeat id tags that may impede interactivity of inputs */}
+            {!showLayer && (
+              <ExampleWrapper
+                background={
+                  ExampleWrapper === ResponsiveContainer && background
+                    ? background
+                    : undefined
+                }
+                screen={screen}
+                width={width}
               >
-                {children}
-              </ResponsiveContext.Provider>
-            </ExampleWrapper>
+                <ResponsiveContext.Provider
+                  value={screen === screens.mobile && 'small'}
+                >
+                  {children}
+                </ResponsiveContext.Provider>
+              </ExampleWrapper>
+            )}
           </Box>
           {(designer || docs || figma || screenContainer || template) && (
             <ExampleControls


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

Updates Example so that when the Layer is open, the inline example is not shown. This remedies an issue where RadioButtonGroup was not clickable in an open layer because the repeat id tag conflicted with the inline example.

Also, wizard example was updated so it has a unique id/for combination from others on the page.

#### Where should the reviewer start?
aries-site/src/layouts/content/Example/Example.js

#### What testing has been done on this PR?
Click radiobuttongroup in inline example, then open layer and click. Should be able to select options.

#### How should this be manually tested?
Same as above.

#### Any background context you want to provide?
RadioButtonGroup was no clickable when layer in example opened.

#### What are the relevant issues?
Closes #1031 

#### Screenshots (if appropriate)

#### Should this PR be mentioned in Design System updates?
No.

#### Is this change backwards compatible or is it a breaking change?
Yes, backwards compatible.