### PR TITLE
fix focus on textinput

### DIFF
--- a/aries-site/src/examples/cardPreviews/textinput.js
+++ b/aries-site/src/examples/cardPreviews/textinput.js
@@ -7,15 +7,15 @@ export const TextInputPreview = () => {
       <FormField
         htmlFor="focus-id"
         name="focus"
-        style={{
-          boxShadow: '0 0 2px 2px #00E8CF',
-          borderRadius: '4px',
-        }}
       >
         <TextInput
           aria-label="preview"
           id="focus-id"
           name="focus"
+          style={{
+            boxShadow: '0 0 2px 2px #00E8CF',
+            borderRadius: '4px',
+          }}
           placeholder="Enter a username"
           tabIndex={-1}
         />


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
This PR fixes the focus on the `textinput` 
#### Where should the reviewer start?
preview/textinput
#### What testing has been done on this PR?

#### How should this be manually tested?

#### Any background context you want to provide?
<img width="346" alt="Screen Shot 2020-08-17 at 8 24 51 PM" src="https://user-images.githubusercontent.com/42451602/90463609-9f5d6300-e0c8-11ea-8feb-a4c673a10bfd.png">

#### What are the relevant issues?
just saw this as I was going through site focus color was on `formfield` not textinput
#### Screenshots (if appropriate)

#### Should this PR be mentioned in Design System updates?
no
#### Is this change backwards compatible or is it a breaking change?
 backwards compatible