### PR TITLE
Remove lingering local theme elements

### DIFF
--- a/aries-site/src/themes/aries.js
+++ b/aries-site/src/themes/aries.js
@@ -1,36 +1,9 @@
 import { hpe } from 'grommet-theme-hpe';
-import { deepMerge, normalizeColor } from 'grommet/utils';
+import { deepMerge } from 'grommet/utils';
 
 export const aries = deepMerge(hpe, {
-  // To be stripped out once theme changes are made in grommet-theme-hpe
-  rangeInput: {
-    thumb: {
-      color: {
-        dark: 'background-front',
-        light: 'background',
-      },
-      extend: ({ theme }) => `
-        border: 2px solid ${
-          theme.global.colors.text[theme.dark ? 'dark' : 'light']
-        };
-      `,
-    },
-    track: {
-      extend: ({ max, theme, value }) => {
-        const lowerTrack = normalizeColor('brand', theme);
-        const upperTrack = normalizeColor('background-contrast', theme);
-        const trackPoint = `${(value / max) * 100}%`;
-
-        return `background: linear-gradient(
-          to right, 
-          ${lowerTrack}, 
-          ${lowerTrack} ${trackPoint},
-          ${upperTrack} ${trackPoint},
-          ${upperTrack}
-        );`;
-      },
-    },
-  },
+  // keeping file for use as playground for future theme adjusments that need
+  // to be quickly tested
 });
 
 export const { colors } = aries.global;


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
Removes lingering rangeInput theme elements that are being moved to grommet-theme-hpe in [this PR](https://github.com/grommet/grommet-theme-hpe/pull/103). I am leaving the file in the site because it serves as a quick playground to assess theme updates.

Should be merged after https://github.com/grommet/grommet-theme-hpe/pull/103 merges.
#### Where should the reviewer start?
aries-site/src/themes/aries.js

#### What testing has been done on this PR?

#### How should this be manually tested?

#### Any background context you want to provide?

#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Should this PR be mentioned in Design System updates?
No.

#### Is this change backwards compatible or is it a breaking change?
Some visual changes, but they are intended to align with the Figma files.