### PR TITLE
Add visualizations section to components page

### DIFF
--- a/aries-site/src/pages/components/index.js
+++ b/aries-site/src/pages/components/index.js
@@ -52,6 +52,11 @@ const Components = () => (
         <Subsection name="Inputs">
           <CardGrid cards={cards.filter(card => card.category === 'Inputs')} />
         </Subsection>
+        <Subsection name="Visualizations">
+          <CardGrid
+            cards={cards.filter(card => card.category === 'Visualizations')}
+          />
+        </Subsection>
       </ContentSection>
     </Box>
   </Layout>


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

NO RELEVANT PREVIEW

#### What does this PR do?

This adds a "Visualizations" section to the components page for any related component cards related to live under. Example components would be Card, Table, Chart, etc.

#### Where should the reviewer start?

aries-site/src/pages/components/index.js 

#### What testing has been done on this PR?

#### How should this be manually tested?

#### Any background context you want to provide?

#### What are the relevant issues?

https://github.com/hpe-design/design-system/issues/1014 & https://github.com/hpe-design/design-system/issues/1010

#### Screenshots (if appropriate)

#### Should this PR be mentioned in Design System updates?

No

#### Is this change backwards compatible or is it a breaking change?

Backwards compatible