### PR TITLE
Add Card theme defaults

### DIFF
--- a/aries-site/src/components/cards/ContentCard.js
+++ b/aries-site/src/components/cards/ContentCard.js
@@ -20,14 +20,12 @@ export const ContentCard = forwardRef(({ topic, minimal, ...rest }, ref) => {
   const darkMode = useDarkMode();
   return (
     <StyledCard
-      // background="background-front"
       elevation={isFocused ? 'medium' : 'small'}
       fill
       onBlur={() => setIsFocused(false)}
       onFocus={() => setIsFocused(true)}
       onMouseOut={() => setIsFocused(false)}
       onMouseOver={() => setIsFocused(true)}
-      // pad="large"
       pad="medium"
       ref={ref}
       {...rest}

--- a/aries-site/src/components/cards/ContentCard.js
+++ b/aries-site/src/components/cards/ContentCard.js
@@ -20,14 +20,15 @@ export const ContentCard = forwardRef(({ topic, minimal, ...rest }, ref) => {
   const darkMode = useDarkMode();
   return (
     <StyledCard
-      background="background-front"
+      // background="background-front"
       elevation={isFocused ? 'medium' : 'small'}
       fill
       onBlur={() => setIsFocused(false)}
       onFocus={() => setIsFocused(true)}
       onMouseOut={() => setIsFocused(false)}
       onMouseOver={() => setIsFocused(true)}
-      pad="large"
+      // pad="large"
+      pad="medium"
       ref={ref}
       {...rest}
     >

--- a/aries-site/src/components/content/PageBackground.js
+++ b/aries-site/src/components/content/PageBackground.js
@@ -41,7 +41,7 @@ export const PageBackground = ({ backgroundImage }) => {
             </Box>
             {/* Empty card restricts width so it switches to one column
             layout at same time as main content */}
-            <Card elevation="none" />
+            <Card background="none" elevation="none" />
           </Grid>
         </Box>
       )}

--- a/aries-site/src/examples/components/card/CardAnatomy.js
+++ b/aries-site/src/examples/components/card/CardAnatomy.js
@@ -13,10 +13,7 @@ export const CardAnatomy = () => (
         title="Title of the Card"
         subtitle="Subtext to provide further context"
       />
-      <Box
-        gap="xsmall"
-        pad={{ top: 'xsmall', bottom: 'medium', horizontal: 'medium' }}
-      >
+      <Box gap="xsmall" pad={{ top: 'medium' }}>
         <ContentBlock
           height={spacing.medium}
           width="100%"
@@ -28,12 +25,7 @@ export const CardAnatomy = () => (
         <ContentBlock height={spacing.medium} width="small" />
       </Box>
     </CardBody>
-    <CardFooter
-      pad={{ horizontal: 'medium', vertical: 'small' }}
-      align="center"
-      gap="small"
-      justify="start"
-    >
+    <CardFooter align="center" gap="small" justify="start">
       <Info />
       <Text>
         Versatile area for presenting context, meta data, or other related
@@ -44,12 +36,7 @@ export const CardAnatomy = () => (
 );
 
 const Identifier = ({ title, subtitle, icon }) => (
-  <Box
-    direction="row"
-    gap="small"
-    align="center"
-    pad={{ horizontal: 'small', vertical: 'medium' }}
-  >
+  <Box direction="row" gap="small" align="center">
     <Box pad={{ vertical: 'xsmall' }}>{icon}</Box>
     <Box>
       <Text color="text-strong" size="xxlarge" weight="bold">

--- a/aries-site/src/examples/components/card/CardExample.js
+++ b/aries-site/src/examples/components/card/CardExample.js
@@ -47,7 +47,7 @@ export const CardExample = () => {
       onMouseOut={() => setIsFocused(false)}
       onMouseOver={() => setIsFocused(true)}
     >
-      <CardBody>
+      <CardBody pad="none">
         <Identifier
           title="Network Traffic"
           subtitle="Bandwidth Utilization - Last 30 Days"
@@ -57,7 +57,7 @@ export const CardExample = () => {
           <KPIChart id="metric-0" data={mockData} />
         </Box>
       </CardBody>
-      <CardFooter background="background-back" pad="medium">
+      <CardFooter background="background-back">
         <KPISummary instances={capacityWarnings} statusColor="status-warning" />
       </CardFooter>
     </StyledCard>

--- a/aries-site/src/examples/components/card/CardMeterExample.js
+++ b/aries-site/src/examples/components/card/CardMeterExample.js
@@ -16,7 +16,7 @@ export const CardMeterExample = () => (
     }}
     width="medium"
   >
-    <CardBody pad="medium" gap="medium">
+    <CardBody gap="medium">
       <Identifier
         title="Availability"
         subtitle="Uptime - Last 30 Days"
@@ -41,7 +41,7 @@ export const CardMeterExample = () => (
         />
       </Box>
     </CardBody>
-    <CardFooter pad="medium">
+    <CardFooter>
       <KPISummary
         message={`${mockAvailability * 100}% vs. SLA 99.5%`}
         statusColor="status-critical"

--- a/aries-site/src/examples/components/card/CardWithFooter.js
+++ b/aries-site/src/examples/components/card/CardWithFooter.js
@@ -10,11 +10,7 @@ export const CardWithFooter = () => (
       title="OmniStackVC-10"
       subtitle="LA_cluster_1"
     />
-    <CardFooter
-      pad={{ horizontal: 'medium', vertical: 'small' }}
-      align="center"
-      justify="start"
-    >
+    <CardFooter align="center" justify="start">
       <Alert />
       <Text weight="bold">Expired</Text>
     </CardFooter>

--- a/aries-site/src/examples/components/card/CardWithImage.js
+++ b/aries-site/src/examples/components/card/CardWithImage.js
@@ -9,7 +9,7 @@ export const CardWithImage = () => (
         fit="cover"
       />
     </Box>
-    <CardBody gap="xsmall" pad="medium">
+    <CardBody gap="xsmall">
       <Box>
         <Text color="text-strong" size="xxlarge" weight="bold">
           HPE HQ

--- a/aries-site/src/examples/components/card/SimpleCard.js
+++ b/aries-site/src/examples/components/card/SimpleCard.js
@@ -1,17 +1,19 @@
 import React from 'react';
-import { Box, Card, Text } from 'grommet';
+import { Box, Card, CardBody, Text } from 'grommet';
 import { Hpe } from 'grommet-icons';
 
 export const SimpleCard = () => (
-  <Card pad="medium" width="medium">
-    <Box direction="row" gap="small">
-      <Hpe size="large" color="plain" />
-      <Box>
-        <Text color="text-strong" size="xxlarge" weight="bold">
-          HPE
-        </Text>
-        <Text color="text-strong">Design System</Text>
+  <Card width="medium">
+    <CardBody>
+      <Box direction="row" gap="small">
+        <Hpe size="large" color="plain" />
+        <Box>
+          <Text color="text-strong" size="xxlarge" weight="bold">
+            HPE
+          </Text>
+          <Text color="text-strong">Design System</Text>
+        </Box>
       </Box>
-    </Box>
+    </CardBody>
   </Card>
 );

--- a/aries-site/src/layouts/content/PageIntro.js
+++ b/aries-site/src/layouts/content/PageIntro.js
@@ -13,8 +13,10 @@ export const PageIntro = ({ children, ...rest }) => {
       >
         {/* Empty card allows vertical space for background image to 
         show on mobile */}
-        <Card elevation="none" height="small" />
-        <Card elevation="none">{children}</Card>
+        <Card background="none" elevation="none" height="small" />
+        <Card background="none" elevation="none">
+          {children}
+        </Card>
       </Grid>
     </Box>
   );

--- a/aries-site/src/themes/aries.js
+++ b/aries-site/src/themes/aries.js
@@ -4,6 +4,22 @@ import { deepMerge } from 'grommet/utils';
 export const aries = deepMerge(hpe, {
   // keeping file for use as playground for future theme adjusments that need
   // to be quickly tested
+
+  // Remove from this file once merged into grommet-theme-hpe
+  card: {
+    container: {
+      background: 'background-front',
+    },
+    body: {
+      pad: 'medium',
+    },
+    footer: {
+      pad: { horizontal: 'medium', vertical: 'small' },
+    },
+    header: {
+      pad: 'medium',
+    },
+  },
 });
 
 export const { colors } = aries.global;


### PR DESCRIPTION


<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
- Adds Card theme defaults for common prop settings
- Simplify card examples by removing props
- Update ContentCard and other DS site specific card components

#### Where should the reviewer start?

- aries.js
- components/card page in both light and dark modes
- each of the index pages (home, foundation, etc. ) to verify the page intros and card grids display as expected

#### What testing has been done on this PR?

Visual review

#### How should this be manually tested?

Visual review (in light and dark) of: 
- components/card page in both light and dark modes
- each of the index pages (home, foundation, etc. ) to verify the page intros and card grids display as expected

#### Any background context you want to provide?

#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Should this PR be mentioned in Design System updates?

#### Is this change backwards compatible or is it a breaking change?

Backwards compatible.
