### PR TITLE
Fix example height calculation

### DIFF
--- a/aries-site/src/layouts/content/Example/Container.js
+++ b/aries-site/src/layouts/content/Example/Container.js
@@ -18,7 +18,7 @@ export const Container = ({
   // Height for template screen needs to be between medium and large
   // to maintain aspect ratio, so this is small + medium
   const { small, medium } = defaultProps.theme.global.size;
-  const aspectHeight = `${Number(medium) + Number(small)}px`;
+  const aspectHeight = `${parseInt(medium, 10) + parseInt(small, 10)}px`;
 
   let height;
   if (template || screenContainer) height = aspectHeight;


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
Noticed that recent horizontal example changes was using `Number` instead of `parseInt` -- this wasn't properly calculating the height for template or screen container examples. This reverts to using `parseInt` to fix.

#### Where should the reviewer start?

#### What testing has been done on this PR?

#### How should this be manually tested?

#### Any background context you want to provide?

#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Should this PR be mentioned in Design System updates?

#### Is this change backwards compatible or is it a breaking change?
